### PR TITLE
HMRC-911,912: Adds services to revoke/delete an api key

### DIFF
--- a/app/services/delete_api_key.rb
+++ b/app/services/delete_api_key.rb
@@ -1,0 +1,17 @@
+class DeleteApiKey
+  def initialize(api_gateway_client = Aws::APIGateway::Client.new)
+    @api_gateway_client = api_gateway_client
+  end
+
+  def call(api_key)
+    result = @api_gateway_client.delete_api_key(api_key: api_key.api_gateway_id)
+
+    api_key.destroy! if result.successful?
+
+    api_key
+  rescue StandardError => e
+    Rails.logger.error("Error updating API key: #{e.message}")
+
+    raise
+  end
+end

--- a/app/services/revoke_api_key.rb
+++ b/app/services/revoke_api_key.rb
@@ -1,0 +1,33 @@
+class RevokeApiKey
+  def initialize(api_gateway_client = Aws::APIGateway::Client.new)
+    @api_gateway_client = api_gateway_client
+  end
+
+  def call(api_key)
+    result = update_api_gateway(api_key)
+
+    api_key.enabled = false
+    api_key.save! if result.successful?
+
+    api_key
+  rescue StandardError => e
+    Rails.logger.error("Error updating API key: #{e.message}")
+
+    raise
+  end
+
+private
+
+  def update_api_gateway(api_key)
+    @api_gateway_client.update_api_key(
+      api_key: api_key.api_gateway_id,
+      patch_operations: [
+        {
+          op: "replace",
+          path: "/enabled",
+          value: "false",
+        },
+      ],
+    )
+  end
+end

--- a/spec/factories/api_keys.rb
+++ b/spec/factories/api_keys.rb
@@ -6,5 +6,6 @@ FactoryBot.define do
     enabled { false }
     secret { "MyString" }
     usage_plan_id { "MyString" }
+    description { "An api key" }
   end
 end

--- a/spec/services/delete_api_key_spec.rb
+++ b/spec/services/delete_api_key_spec.rb
@@ -1,0 +1,30 @@
+require "rails_helper"
+
+RSpec.describe DeleteApiKey do
+  subject(:delete_api_key) { described_class.new(api_gateway_client) }
+
+  let(:api_gateway_client) { Aws::APIGateway::Client.new(stub_responses: true) }
+  let(:api_key) { create(:api_key) }
+
+  describe "#call" do
+    context "when the result of deleting in api gateway is successful" do
+      before { api_gateway_client.stub_responses(:delete_api_key) }
+
+      it "deletes the api key" do
+        delete_api_key.call(api_key)
+
+        expect(ApiKey.exists?(api_key.id)).to be(false)
+      end
+    end
+
+    context "when the result of deleting in api gateway is unsuccessful" do
+      before { api_gateway_client.stub_responses(:delete_api_key, "error") }
+
+      it "does not delete the api key", :aggregate_failures do
+        expect { delete_api_key.call(api_key) }.to raise_error(StandardError)
+
+        expect(ApiKey.exists?(api_key.id)).to be(true)
+      end
+    end
+  end
+end

--- a/spec/services/revoke_api_key_spec.rb
+++ b/spec/services/revoke_api_key_spec.rb
@@ -1,0 +1,39 @@
+require "rails_helper"
+
+RSpec.describe RevokeApiKey do
+  subject(:revoke_api_key) { described_class.new(api_gateway_client) }
+
+  let(:api_gateway_client) { Aws::APIGateway::Client.new(stub_responses: true) }
+  let(:api_key) { create(:api_key, api_gateway_id: "api-gateway-id-123", enabled: true) }
+
+  describe "#call" do
+    context "when the result of revoking api gateway is successful" do
+      before do
+        api_gateway_client.stub_responses(
+          :update_api_key,
+          id: api_key.api_gateway_id,
+          name: api_key.api_key_id,
+          description: api_key.description,
+          enabled: false,
+        )
+      end
+
+      it "changes the api key enabled flag to `false`" do
+        expect { revoke_api_key.call(api_key) }
+          .to change { api_key.reload.enabled }.from(true).to(false)
+      end
+    end
+
+    context "when the result of revoking in api gateway is unsuccessful" do
+      before do
+        api_gateway_client.stub_responses(:update_api_key, "error")
+      end
+
+      it "does not change the api key enabled flag to `false`", :aggregate_failures do
+        expect { revoke_api_key.call(api_key) }.to raise_error(StandardError)
+
+        expect(api_key.reload.enabled).to be(true)
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Jira link

[HMRC-911](https://transformuk.atlassian.net/browse/HMRC-911)
[HMRC-912](https://transformuk.atlassian.net/browse/HMRC-912)

## What?

I have:

- [x] Added service and spec to revoke an api gateway key
- [x] Added service and spec to delete an api gateway key

## Why?

I am doing this because:

- Revoking happens in across all environments
- Deleting happens in test/development environments to tidy up keys used as part of integrations
