### PR TITLE
HMRC-928: Adds localstack

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,4 +1,3 @@
-AWS_DEFAULT_REGION=eu-west-2
 ENCRYPTION_KEY=+WxrxtmkNdODyHrrwh1K2msWts1HVCCf7B98Q0odcUs=
 PORT=3004
 REST_API_ID="xxxxxxxxxx",

--- a/.env.test
+++ b/.env.test
@@ -1,4 +1,3 @@
-AWS_DEFAULT_REGION=eu-west-2
 ENCRYPTION_KEY=+WxrxtmkNdODyHrrwh1K2msWts1HVCCf7B98Q0odcUs=
 REST_API_ID="xxxxxxxxxx",
 REST_STAGE_NAME="test",

--- a/README.md
+++ b/README.md
@@ -1,3 +1,25 @@
 # trade-tariff-dev-hub
 
 Ruby app giving FPO operators the ability to manage their own API credentials.
+
+## Getting started
+
+### Localstack
+
+We use localstack to simulate the aws services we use to enable the dev hub
+to run locally.
+
+You'll need docker and docker-compose installed with your package manager.
+
+To bring up localstack run the following command:
+
+```bash
+docker-compose up
+```
+
+> [!TIP]
+> If you're on a linux machine you'll want to alias the `host.docker.internal` namespace
+>
+> ```hosts
+> 127.0.0.1 host.docker.internal
+> ```

--- a/config/initializers/aws.rb
+++ b/config/initializers/aws.rb
@@ -1,0 +1,32 @@
+if Rails.env.development?
+  localstack_running = Timeout.timeout(1) do
+    begin
+      s = TCPSocket.new("host.docker.internal", "4566")
+      s.close
+      true
+    rescue Errno::ECONNREFUSED, Errno::EHOSTUNREACH, Timeout::Error, Socket::ResolutionError
+      false
+    end
+  end
+
+  if localstack_running
+    Aws.config.update({
+      region: 'us-east-1',
+      endpoint: 'http://localhost:4566',
+      credentials: Aws::Credentials.new('dummy', 'dummy')
+    })
+
+    api_gateway_client = Aws::APIGateway::Client.new
+    rest_api_name = "development-trade-tariff-lambdas-fpo-search"
+
+    response = api_gateway_client.get_rest_apis
+    rest_api = response.items.find { |api| api.name == rest_api_name }
+
+    unless rest_api
+      response = api_gateway_client.create_rest_api(name: rest_api_name)
+      rest_api = response.id.presence || raise("Failed to create REST API")
+    end
+
+    ENV['REST_API_ID'] = rest_api.try(:id) || rest_api
+  end
+end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,6 @@
+services:
+  localstack:
+    image: localstack/localstack:latest
+    ports:
+      - 4566:4566           # LocalStack edge port
+      - 4510-4559:4510-4559 # maps various AWS services ports


### PR DESCRIPTION
# Jira link

[HMRC-928](https://transformuk.atlassian.net/browse/HMRC-928)

## What?

I have:

- [x] Populate seeds.rb
- [x] Dynamically enable/hint at using localstack when the user starts a rails console in development mode
- [x] Add a docker-compose file for local development with localstack in it

## Why?

I am doing this because:

- This is needed for easier local development
