### PR TITLE
BAU: Update enabled to default to true

### DIFF
--- a/db/migrate/20250312091826_create_api_keys.rb
+++ b/db/migrate/20250312091826_create_api_keys.rb
@@ -4,7 +4,7 @@ class CreateApiKeys < ActiveRecord::Migration[8.0]
       t.belongs_to :organisation, null: false, foreign_key: true, type: :uuid
       t.string :api_key_id, null: false
       t.string :api_gateway_id, null: false
-      t.boolean :enabled
+      t.boolean :enabled, default: true
       t.string :secret, null: false
       t.string :usage_plan_id, null: false
       t.string :description, null: false


### PR DESCRIPTION
# Jira link

Derives from work on:
[HMRC-828](https://transformuk.atlassian.net/browse/HMRC-828

## What?

I have:

- [x] Updated api keys table migration to include a default to true for the enabled status

## Why?

I am doing this because:

- It defaulted to nil which is a falsy value, messing up with the status on the UI 
