### PR TITLE
HMRC-877: Verification wizard and user states

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -2,3 +2,4 @@ DELETION_ENABLED=true
 ENCRYPTION_KEY=+WxrxtmkNdODyHrrwh1K2msWts1HVCCf7B98Q0odcUs=
 REST_API_ID="xxxxxxxxxx",
 REST_STAGE_NAME="test",
+SCP_ENABLED=false

--- a/Gemfile
+++ b/Gemfile
@@ -6,14 +6,17 @@ gem "rails"
 
 gem "aws-sdk-apigateway"
 gem "aws-sdk-dynamodb"
-gem "govuk-components"
-gem "govuk_design_system_formbuilder"
 gem "importmap-rails"
 gem "ostruct"
 gem "paper_trail"
 gem "pg"
 gem "propshaft"
 gem "puma", ">= 5.0"
+
+# Govuk Design System
+gem "govuk-components"
+gem "govuk_design_system_formbuilder"
+gem "wizard_steps"
 
 # Government Gateway integration
 gem "omniauth_openid_connect"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -431,6 +431,7 @@ GEM
       base64
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
+    wizard_steps (0.1.4)
     zeitwerk (2.7.2)
 
 PLATFORMS
@@ -470,6 +471,7 @@ DEPENDENCIES
   ruby-lsp-rspec
   shoulda-matchers
   webmock
+  wizard_steps
 
 RUBY VERSION
    ruby 3.4.2p28

--- a/app/controllers/authenticated_controller.rb
+++ b/app/controllers/authenticated_controller.rb
@@ -20,6 +20,8 @@ class AuthenticatedController < ApplicationController
       redirect_to user_verification_steps_path
     when "pending"
       redirect_to completed_user_verification_steps_path(application_reference: current_user.application_reference)
+    when "rejected"
+      redirect_to rejected_user_verification_steps_path(application_reference: current_user.application_reference)
     end
   end
 

--- a/app/controllers/authenticated_controller.rb
+++ b/app/controllers/authenticated_controller.rb
@@ -1,13 +1,26 @@
 # frozen_string_literal: true
 
 class AuthenticatedController < ApplicationController
-  before_action :require_authentication
+  before_action :require_authentication,
+                :require_registration
+
   before_action :set_paper_trail_whodunnit
 
   def require_authentication
     return if current_user.present? || Rails.env.test?
 
     redirect_to "/auth/openid_connect"
+  end
+
+  def require_registration
+    return if Rails.env.test?
+
+    case current_user&.status
+    when "unregistered"
+      redirect_to user_verification_steps_path
+    when "pending"
+      redirect_to completed_user_verification_steps_path(application_reference: current_user.application_reference)
+    end
   end
 
   def user_profile

--- a/app/controllers/authenticated_controller.rb
+++ b/app/controllers/authenticated_controller.rb
@@ -2,18 +2,18 @@
 
 class AuthenticatedController < ApplicationController
   before_action :require_authentication,
-                :require_registration
-
-  before_action :set_paper_trail_whodunnit
+                :require_registration,
+                :set_paper_trail_whodunnit
 
   def require_authentication
-    return if current_user.present? || Rails.env.test?
+    return if current_user.present?
+    return unless TradeTariffDevHub.scp_enabled?
 
     redirect_to "/auth/openid_connect"
   end
 
   def require_registration
-    return if Rails.env.test?
+    return unless TradeTariffDevHub.scp_enabled?
 
     case current_user&.status
     when "unregistered"

--- a/app/controllers/user_verification/steps_controller.rb
+++ b/app/controllers/user_verification/steps_controller.rb
@@ -1,0 +1,43 @@
+module UserVerification
+  class StepsController < AuthenticatedController
+    include WizardSteps
+
+    def on_complete(result)
+      redirect_to action: :completed, application_reference: result
+    end
+
+  private
+
+    self.wizard_class = Wizard
+
+    def wizard_context
+      {
+        email_address: user_profile["email"],
+        current_user: current_user,
+      }
+    end
+
+    def wizard_store_key
+      :user_verification
+    end
+
+    def step_path(step_id = params[:id])
+      user_verification_step_path(step_id)
+    end
+
+    def step_param_key
+      "#{wizard_store_key}_steps_#{current_step.key}"
+    end
+
+    # NOTE: This override supports array type form parameters which needs adding to the gem
+    def step_params
+      return params.require(step_param_key).permit(terms: []) if review_answers?
+
+      super
+    end
+
+    def review_answers?
+      params.key?("user_verification_steps_review_answers")
+    end
+  end
+end

--- a/app/controllers/user_verification/steps_controller.rb
+++ b/app/controllers/user_verification/steps_controller.rb
@@ -8,6 +8,8 @@ module UserVerification
       redirect_to action: :completed, application_reference: result
     end
 
+    def rejected; end
+
   private
 
     self.wizard_class = Wizard

--- a/app/controllers/user_verification/steps_controller.rb
+++ b/app/controllers/user_verification/steps_controller.rb
@@ -1,5 +1,7 @@
 module UserVerification
   class StepsController < AuthenticatedController
+    skip_before_action :require_registration
+
     include WizardSteps
 
     def on_complete(result)

--- a/app/helpers/api_keys_helper.rb
+++ b/app/helpers/api_keys_helper.rb
@@ -8,7 +8,11 @@ module ApiKeysHelper
   end
 
   def api_key_status(api_key)
-    api_key.enabled ? "Active" : "Revoked on #{api_key.updated_at.strftime('%d %B %Y')}"
+    if api_key.enabled
+      "Active"
+    else
+      "Revoked on #{api_key.updated_at.to_date.to_formatted_s(:govuk)}"
+    end
   end
 
   def creation_date(api_key)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,4 +1,12 @@
 module ApplicationHelper
+  def feedback_link
+    govuk_link_to "What did you think of this service?", feedback_url, target: "_blank"
+  end
+
+  def documentation_link
+    govuk_link_to "API documentation (opens in new tab)", documentation_url, target: "_blank"
+  end
+
   def documentation_url
     ENV.fetch(
       "DOCUMENTATION_URL",
@@ -18,5 +26,24 @@ module ApplicationHelper
       "TERMS_AND_CONDITIONS_URL",
       "https://api.trade-tariff.service.gov.uk/fpo/terms-and-conditions.html",
     )
+  end
+
+  def fpo_usage_terms
+    option = Struct.new(:id, :text)
+    range = (1..4)
+    range.map do |index|
+      option.new(
+        index,
+        t("fpo_usage_terms.term#{index}"),
+      )
+    end
+  end
+
+  def fpo_usage_terms_hint
+    t("fpo_usage_terms.terms_hint_html", terms_link: terms_link)
+  end
+
+  def terms_link
+    govuk_link_to "terms and conditions of the Commodity Code Identification Tool (opens in new tab)", terms_and_conditions_url, target: "_blank", rel: "noopener noreferrer"
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,31 +1,14 @@
 module ApplicationHelper
-  def feedback_link
-    govuk_link_to "What did you think of this service?", feedback_url, target: "_blank"
-  end
-
   def documentation_link
-    govuk_link_to "API documentation (opens in new tab)", documentation_url, target: "_blank"
+    govuk_link_to "API documentation (opens in new tab)", TradeTariffDevHub.documentation_url, target: "_blank"
   end
 
-  def documentation_url
-    ENV.fetch(
-      "DOCUMENTATION_URL",
-      "https://api.trade-tariff.service.gov.uk/fpo.html",
-    )
+  def feedback_link
+    govuk_link_to "What did you think of this service?", TradeTariffDevHub.feedback_url, target: "_blank"
   end
 
-  def feedback_url
-    ENV.fetch(
-      "FEEDBACK_URL",
-      "http://localhost:3001/feedback",
-    )
-  end
-
-  def terms_and_conditions_url
-    ENV.fetch(
-      "TERMS_AND_CONDITIONS_URL",
-      "https://api.trade-tariff.service.gov.uk/fpo/terms-and-conditions.html",
-    )
+  def terms_link
+    govuk_link_to "terms and conditions of the Commodity Code Identification Tool (opens in new tab)", TradeTariffDevHub.terms_and_conditions_url, target: "_blank", rel: "noopener noreferrer"
   end
 
   def fpo_usage_terms
@@ -41,9 +24,5 @@ module ApplicationHelper
 
   def fpo_usage_terms_hint
     t("fpo_usage_terms.terms_hint_html", terms_link: terms_link)
-  end
-
-  def terms_link
-    govuk_link_to "terms and conditions of the Commodity Code Identification Tool (opens in new tab)", terms_and_conditions_url, target: "_blank", rel: "noopener noreferrer"
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -22,7 +22,7 @@ module ApplicationHelper
     end
   end
 
-  def fpo_usage_terms_hint
-    t("fpo_usage_terms.terms_hint_html", terms_link: terms_link)
+  def user_verification_steps_review_answers_terms_hint
+    t("helpers.hint.user_verification_steps_review_answers.terms_html", terms_link: terms_link)
   end
 end

--- a/app/lib/trade_tariff_dev_hub.rb
+++ b/app/lib/trade_tariff_dev_hub.rb
@@ -1,5 +1,9 @@
 module TradeTariffDevHub
   class << self
+    def scp_enabled?
+      ENV.fetch("SCP_ENABLED", "true") == "true"
+    end
+
     def deletion_enabled?
       ENV.fetch("DELETION_ENABLED", "false") == "true"
     end

--- a/app/lib/trade_tariff_dev_hub.rb
+++ b/app/lib/trade_tariff_dev_hub.rb
@@ -3,5 +3,9 @@ module TradeTariffDevHub
     def deletion_enabled?
       ENV.fetch("DELETION_ENABLED", "false") == "true"
     end
+
+    def eori_lookup_url
+      ENV.fetch("EORI_LOOKUP_URL", "https://test-api.service.hmrc.gov.uk/customs/eori/lookup/check-multiple-eori")
+    end
   end
 end

--- a/app/lib/trade_tariff_dev_hub.rb
+++ b/app/lib/trade_tariff_dev_hub.rb
@@ -4,6 +4,27 @@ module TradeTariffDevHub
       ENV.fetch("DELETION_ENABLED", "false") == "true"
     end
 
+    def documentation_url
+      ENV.fetch(
+        "DOCUMENTATION_URL",
+        "https://api.trade-tariff.service.gov.uk/fpo.html",
+      )
+    end
+
+    def feedback_url
+      ENV.fetch(
+        "FEEDBACK_URL",
+        "http://localhost:3001/feedback",
+      )
+    end
+
+    def terms_and_conditions_url
+      ENV.fetch(
+        "TERMS_AND_CONDITIONS_URL",
+        "https://api.trade-tariff.service.gov.uk/fpo/terms-and-conditions.html",
+      )
+    end
+
     def eori_lookup_url
       ENV.fetch("EORI_LOOKUP_URL", "https://test-api.service.hmrc.gov.uk/customs/eori/lookup/check-multiple-eori")
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,6 +3,8 @@ class User < ApplicationRecord
 
   belongs_to :organisation
 
+  delegate :status, :application_reference, to: :organisation
+
   def self.from_profile!(government_gateway_profile)
     organisation = Organisation.from_profile!(government_gateway_profile)
 

--- a/app/models/user_verification/steps/details.rb
+++ b/app/models/user_verification/steps/details.rb
@@ -10,7 +10,6 @@ module UserVerification
       attribute :eori_number, :string
       attribute :ukacs_reference, :string
       attribute :email_address, :string
-      attribute :application_reference, :string
 
       validates :organisation_name, presence: true
       validates :ukacs_reference, presence: true
@@ -18,6 +17,8 @@ module UserVerification
       validates :eori_number, presence: true
 
       validate :validate_eori_number
+
+    private
 
       def validate_eori_number
         valid = CheckEoriNumber.new.call(eori_number)

--- a/app/models/user_verification/steps/details.rb
+++ b/app/models/user_verification/steps/details.rb
@@ -1,0 +1,35 @@
+module UserVerification
+  module Steps
+    class Details < WizardSteps::Step
+      def initialize(wizard, store, attributes = {}, *args)
+        super
+        assign_attributes additional_attributes
+      end
+
+      attribute :organisation_name, :string
+      attribute :eori_number, :string
+      attribute :ukacs_reference, :string
+      attribute :email_address, :string
+      attribute :application_reference, :string
+
+      validates :organisation_name, presence: true
+      validates :ukacs_reference, presence: true
+      validates :email_address, presence: true
+      validates :eori_number, presence: true
+
+      validate :validate_eori_number
+
+      def validate_eori_number
+        valid = CheckEoriNumber.new.call(eori_number)
+
+        errors.add(:eori_number, :invalid) unless valid
+      end
+
+      def additional_attributes
+        return {} if email_address.present?
+
+        { email_address: @wizard.email_address }
+      end
+    end
+  end
+end

--- a/app/models/user_verification/steps/review_answers.rb
+++ b/app/models/user_verification/steps/review_answers.rb
@@ -1,0 +1,21 @@
+module UserVerification
+  module Steps
+    class ReviewAnswers < WizardSteps::Step
+      VALID_TERMS = ["", "1", "2", "3", "4"].freeze
+
+      attribute :terms
+
+      validate :validate_terms
+
+      def validate_terms
+        return if terms == VALID_TERMS
+
+        errors.add(:terms, :blank)
+      end
+
+      def answers
+        @answers ||= @wizard.reviewable_answers_by_step[UserVerification::Steps::Details]
+      end
+    end
+  end
+end

--- a/app/models/user_verification/wizard.rb
+++ b/app/models/user_verification/wizard.rb
@@ -1,0 +1,44 @@
+module UserVerification
+  class Wizard < WizardSteps::Base
+    APPLICATION_REFERENCE_LENGTH = 8
+
+    self.steps = [
+      Steps::Details,
+      Steps::ReviewAnswers,
+    ]
+
+    def email_address
+      @context[:email_address]
+    end
+
+    def current_user
+      @context[:current_user]
+    end
+
+    def do_complete
+      unless organisation.application_reference
+        organisation.update!(
+          uk_acs_reference: answers["ukacs_reference"],
+          organisation_name: answers["organisation_name"],
+          application_reference: answers["application_reference"],
+          status: :pending,
+        )
+
+        current_user.email_address = answers["email_address"]
+        current_user.save! if current_user.changed?
+      end
+
+      organisation.application_reference
+    end
+
+    delegate :organisation, to: :current_user
+
+    def answers
+      @answers ||= reviewable_answers_by_step[UserVerification::Steps::Details]
+    end
+
+    def application_reference
+      current_user.organisation.application_reference.presence || SecureRandom.hex(APPLICATION_REFERENCE_LENGTH / 2)
+    end
+  end
+end

--- a/app/models/user_verification/wizard.rb
+++ b/app/models/user_verification/wizard.rb
@@ -18,9 +18,10 @@ module UserVerification
     def do_complete
       unless organisation.application_reference
         organisation.update!(
+          eori_number: answers["eori_number"],
           uk_acs_reference: answers["ukacs_reference"],
           organisation_name: answers["organisation_name"],
-          application_reference: answers["application_reference"],
+          application_reference: application_reference,
           status: :pending,
         )
 

--- a/app/services/check_eori_number.rb
+++ b/app/services/check_eori_number.rb
@@ -1,0 +1,30 @@
+class CheckEoriNumber
+  def initialize(client = self.class.client)
+    @client = client
+  end
+
+  def call(eori_number)
+    response = @client.post(
+      eori_lookup_url,
+      { eoris: [eori_number] }.to_json,
+      "Accept" => "application/json",
+      "Content-Type" => "application/json",
+    )
+
+    response.status == 200
+  rescue StandardError
+    Rails.logger.error("Error while checking EORI number: #{eori_number}")
+    false
+  end
+
+  delegate :eori_lookup_url, to: TradeTariffDevHub
+
+  def self.client
+    @client ||= Faraday.new do |conn|
+      conn.request :json
+      conn.response :json, content_type: /\bjson$/
+      conn.response :logger, Rails.logger, { headers: true, bodies: true }
+      conn.adapter Faraday.default_adapter
+    end
+  end
+end

--- a/app/views/homepage/index.html.erb
+++ b/app/views/homepage/index.html.erb
@@ -26,7 +26,7 @@
           <li>an email address for essential updates</li>
       </ul>
       <%= govuk_start_button(text: "Start now", href: "/dashboard") %>
-      <h1 class="govuk-heading-m">If you need help</h1>
+      <h2 class="govuk-heading-m">If you need help</h2>
       <p class="govuk-body">
           If you have any further queries relating to the developer hub contact: <a class="govuk-link"
   href="mailto:hmrc-trade-tariff-support-g@digital.hmrc.gov.uk">hmrc-trade-tariff-support-g@digital.hmrc.gov.uk</a>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -43,10 +43,10 @@
   </body>
 
   <%= govuk_footer(meta_items_title: "Helpful links", meta_items: {
-    "API Documentation" => documentation_url,
-    "Feedback" =>  feedback_url,
+    "API Documentation" => TradeTariffDevHub.documentation_url,
+    "Feedback" =>  TradeTariffDevHub.feedback_url,
     "Privacy policy" => "https://hub.trade-tariff.service.gov.uk/privacyPolicy",
     "Cookies" => "#",
-    "Terms and conditions" => terms_and_conditions_url,
+    "Terms and conditions" => TradeTariffDevHub.terms_and_conditions_url,
   }) %>
 </html>

--- a/app/views/user_verification/steps/_details.html.erb
+++ b/app/views/user_verification/steps/_details.html.erb
@@ -13,7 +13,7 @@ Enter the following information about your organisation. This will be used to ve
 <%= f.govuk_text_field :ukacs_reference %>
 <%= f.govuk_email_field :email_address, autocomplete: "email", spellcheck: false %>
 
-<h1 class="govuk-heading-m">If you need help</h1>
+<h2 class="govuk-heading-m">If you need help</h2>
 
 <p class="govuk-body">
     If you have any further queries relating to the developer hub contact: <%= govuk_link_to "hmrc-trade-tariff-support-g@digital.hmrc.gov.uk", "mailto:hmrc-trade-tariff-support-g@digital.hmrc.gov.uk" %>

--- a/app/views/user_verification/steps/_details.html.erb
+++ b/app/views/user_verification/steps/_details.html.erb
@@ -8,23 +8,10 @@ To allow you to use the FPO Commodity Code Identification Tool API we need to ch
 Enter the following information about your organisation. This will be used to verify your account.
 </p>
 
-<%= f.govuk_text_field :organisation_name,
-  label: { text: "What is the name of your organisation?", class: "govuk-label--m" },
-  hint: { text: "This should be the name of the organisation you are accessing the Commodity Code Tool on behalf of." } %>
-
-<%= f.govuk_text_field :eori_number,
-  label: { text: "What is your EORI number?", class: "govuk-label--m" },
-  hint: { text: "Your organisation will have an Economic Operators Registration and Identification (EORI) number." } %>
-
-<%= f.govuk_text_field :ukacs_reference,
-  label: { text: "What is your UK Carrier Scheme (UKC) reference number?", class: "govuk-label--m" },
-  hint: { text: "Your organisation would have received a unique reference number when signing up for the UK Authorised Carrier Scheme." } %>
-
-<%= f.govuk_email_field :email_address,
-  label: { text: "Your work email address", class: "govuk-label--m" },
-  hint: { text: "We will only use your email address to send essential updates regarding the Commodity Code Identification Tool and your verification request." },
-  autocomplete: "email",
-  spellcheck: false %>
+<%= f.govuk_text_field :organisation_name %>
+<%= f.govuk_text_field :eori_number %>
+<%= f.govuk_text_field :ukacs_reference %>
+<%= f.govuk_email_field :email_address, autocomplete: "email", spellcheck: false %>
 
 <h1 class="govuk-heading-m">If you need help</h1>
 

--- a/app/views/user_verification/steps/_details.html.erb
+++ b/app/views/user_verification/steps/_details.html.erb
@@ -1,0 +1,33 @@
+<h1 class="govuk-label govuk-label--l">Register for the FPO Commodity Code Identification Tool API</h1>
+
+<p class="govuk-body">
+To allow you to use the FPO Commodity Code Identification Tool API we need to check that your organisation is UK Carrier Scheme (UKC) registered.
+</p>
+
+<p class="govuk-body">
+Enter the following information about your organisation. This will be used to verify your account.
+</p>
+
+<%= f.govuk_text_field :organisation_name,
+  label: { text: "What is the name of your organisation?", class: "govuk-label--m" },
+  hint: { text: "This should be the name of the organisation you are accessing the Commodity Code Tool on behalf of." } %>
+
+<%= f.govuk_text_field :eori_number,
+  label: { text: "What is your EORI number?", class: "govuk-label--m" },
+  hint: { text: "Your organisation will have an Economic Operators Registration and Identification (EORI) number." } %>
+
+<%= f.govuk_text_field :ukacs_reference,
+  label: { text: "What is your UK Carrier Scheme (UKC) reference number?", class: "govuk-label--m" },
+  hint: { text: "Your organisation would have received a unique reference number when signing up for the UK Authorised Carrier Scheme." } %>
+
+<%= f.govuk_email_field :email_address,
+  label: { text: "Your work email address", class: "govuk-label--m" },
+  hint: { text: "We will only use your email address to send essential updates regarding the Commodity Code Identification Tool and your verification request." },
+  autocomplete: "email",
+  spellcheck: false %>
+
+<h1 class="govuk-heading-m">If you need help</h1>
+
+<p class="govuk-body">
+    If you have any further queries relating to the developer hub contact: <%= govuk_link_to "hmrc-trade-tariff-support-g@digital.hmrc.gov.uk", "mailto:hmrc-trade-tariff-support-g@digital.hmrc.gov.uk" %>
+</p>

--- a/app/views/user_verification/steps/_form.html.erb
+++ b/app/views/user_verification/steps/_form.html.erb
@@ -1,0 +1,13 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_for current_step, url: user_verification_step_path(current_step.key) do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <%= render current_step.key, current_step: current_step, f: f %>
+
+      <%= f.govuk_submit do %>
+         <%= govuk_link_to 'Cancel', root_path %>
+      <% end %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/user_verification/steps/_review_answers.html.erb
+++ b/app/views/user_verification/steps/_review_answers.html.erb
@@ -2,57 +2,57 @@
 
 <h2 class="govuk-heading-m">Application details</h2>
 
-<% f.object.answers.tap do |answers| %>
-    <%= govuk_summary_list do |summary_list|
-      summary_list.with_row do |row|
-        row.with_key { 'Organisation name' }
-        row.with_value { answers["organisation_name"] }
-        row.with_action(
-            text: 'Change',
-            href: user_verification_step_path("details"),
-            visually_hidden_text: 'organisation name',
-        )
-      end
+<%= answers = f.object.answers %>
 
-      summary_list.with_row do |row|
-          row.with_key { 'Organisation EORI' }
-          row.with_value { answers["eori_number"] }
-          row.with_action(
-              text: 'Change',
-              href: user_verification_step_path("details"),
-              visually_hidden_text: 'organisation EORI',
-          )
-      end
+<%= govuk_summary_list do |summary_list|
+  summary_list.with_row do |row|
+    row.with_key { 'Organisation name' }
+    row.with_value { answers["organisation_name"] }
+    row.with_action(
+        text: 'Change',
+        href: user_verification_step_path("details"),
+        visually_hidden_text: 'organisation name',
+    )
+  end
 
-      summary_list.with_row do |row|
-          row.with_key { 'UKC reference' }
-          row.with_value { answers["ukacs_reference"] }
-          row.with_action(
-              text: 'Change',
-              href: user_verification_step_path("details"),
-              visually_hidden_text: 'UKC reference',
-          )
-      end
+  summary_list.with_row do |row|
+      row.with_key { 'Organisation EORI' }
+      row.with_value { answers["eori_number"] }
+      row.with_action(
+          text: 'Change',
+          href: user_verification_step_path("details"),
+          visually_hidden_text: 'organisation EORI',
+      )
+  end
 
-      summary_list.with_row do |row|
-          row.with_key { 'Work email address' }
-          row.with_value { answers["email_address"] }
-          row.with_action(
-              text: 'Change',
-              href: user_verification_step_path("details"),
-              visually_hidden_text: 'work email address',
-          )
-      end
-    end %>
+  summary_list.with_row do |row|
+      row.with_key { 'UKC reference' }
+      row.with_value { answers["ukacs_reference"] }
+      row.with_action(
+          text: 'Change',
+          href: user_verification_step_path("details"),
+          visually_hidden_text: 'UKC reference',
+      )
+  end
 
-    <%= f.govuk_collection_check_boxes :terms,
-      fpo_usage_terms,
-      :id,
-      :text,
-      legend: { text: "Terms and conditions", tag: "h1", size: "l" },
-      hint: { text: user_verification_steps_review_answers_terms_hint }
-    %>
-    <p class="govuk-body">
-      By submitting this application you are confirming that, to the best of your knowledge, the details you are providing are correct.
-    </p>
-<% end %>
+  summary_list.with_row do |row|
+      row.with_key { 'Work email address' }
+      row.with_value { answers["email_address"] }
+      row.with_action(
+          text: 'Change',
+          href: user_verification_step_path("details"),
+          visually_hidden_text: 'work email address',
+      )
+  end
+end %>
+
+<%= f.govuk_collection_check_boxes :terms,
+  fpo_usage_terms,
+  :id,
+  :text,
+  legend: { text: "Terms and conditions", tag: "h1", size: "l" },
+  hint: { text: user_verification_steps_review_answers_terms_hint }
+%>
+<p class="govuk-body">
+  By submitting this application you are confirming that, to the best of your knowledge, the details you are providing are correct.
+</p>

--- a/app/views/user_verification/steps/_review_answers.html.erb
+++ b/app/views/user_verification/steps/_review_answers.html.erb
@@ -50,7 +50,7 @@
       :id,
       :text,
       legend: { text: "Terms and conditions", tag: "h1", size: "l" },
-      hint: { text: fpo_usage_terms_hint }
+      hint: { text: user_verification_steps_review_answers_terms_hint }
     %>
     <p class="govuk-body">
       By submitting this application you are confirming that, to the best of your knowledge, the details you are providing are correct.

--- a/app/views/user_verification/steps/_review_answers.html.erb
+++ b/app/views/user_verification/steps/_review_answers.html.erb
@@ -1,0 +1,58 @@
+<h1 class="govuk-heading-l">Check your answers</h1>
+
+<h2 class="govuk-heading-m">Application details</h2>
+
+<% f.object.answers.tap do |answers| %>
+    <%= govuk_summary_list do |summary_list|
+      summary_list.with_row do |row|
+        row.with_key { 'Organisation name' }
+        row.with_value { answers["organisation_name"] }
+        row.with_action(
+            text: 'Change',
+            href: user_verification_step_path("details"),
+            visually_hidden_text: 'organisation name',
+        )
+      end
+
+      summary_list.with_row do |row|
+          row.with_key { 'Organisation EORI' }
+          row.with_value { answers["eori_number"] }
+          row.with_action(
+              text: 'Change',
+              href: user_verification_step_path("details"),
+              visually_hidden_text: 'organisation EORI',
+          )
+      end
+
+      summary_list.with_row do |row|
+          row.with_key { 'UKC reference' }
+          row.with_value { answers["ukacs_reference"] }
+          row.with_action(
+              text: 'Change',
+              href: user_verification_step_path("details"),
+              visually_hidden_text: 'UKC reference',
+          )
+      end
+
+      summary_list.with_row do |row|
+          row.with_key { 'Work email address' }
+          row.with_value { answers["email_address"] }
+          row.with_action(
+              text: 'Change',
+              href: user_verification_step_path("details"),
+              visually_hidden_text: 'work email address',
+          )
+      end
+    end %>
+
+    <%= f.govuk_collection_check_boxes :terms,
+      fpo_usage_terms,
+      :id,
+      :text,
+      legend: { text: "Terms and conditions", tag: "h1", size: "l" },
+      hint: { text: fpo_usage_terms_hint }
+    %>
+    <p class="govuk-body">
+      By submitting this application you are confirming that, to the best of your knowledge, the details you are providing are correct.
+    </p>
+<% end %>

--- a/app/views/user_verification/steps/completed.html.erb
+++ b/app/views/user_verification/steps/completed.html.erb
@@ -1,0 +1,20 @@
+<%= govuk_panel(title_text: "Application complete") do %>
+        Your reference number
+        <br>
+        <strong><%= params[:application_reference] %></strong>
+<% end %>
+
+<p class="govuk-body">We have sent you a confirmation email.</p>
+
+<h2 class="govuk-heading-m">What happens next</h2>
+
+<p class="govuk-body">We aim to process your application within ten working days.</p>
+
+<p class="govuk-body">We will notify you of the decision by email using the details you have provided in your application.</p>
+
+<p class="govuk-body">
+  In the meantime, you can find out more about the Commodity Code Identification tool by reading the <%= documentation_link %>
+</p>
+<p class="govuk-body">
+  <%= feedback_link %> (takes 30 seconds)
+</p>

--- a/app/views/user_verification/steps/rejected.html.erb
+++ b/app/views/user_verification/steps/rejected.html.erb
@@ -1,0 +1,19 @@
+<h1 class="govuk-heading-l">Your application has been rejected</h1>
+<p class="govuk-body">
+Your application, with reference number <strong><%= params[:application_reference] %></strong>, has been rejected.
+</p>
+
+<p class="govuk-body">
+  A notification of this decision, including further details, has been sent to the email address provided in the application.
+</p>
+
+<p class="govuk-body">
+  For further enquiries relating to this decision and general advice, email <a class="govuk-link"
+  href="mailto:hmrc-trade-tariff-support-g@digital.hmrc.gov.uk">hmrc-trade-tariff-support-g@digital.hmrc.gov.uk</a> using below reference number.
+</p>
+
+<h1 class="govuk-heading-l"><%= params[:application_reference] %></h1>
+<p class="govuk-body">
+<p class="govuk-body">
+  <%= feedback_link %> (takes 30 seconds)
+</p>

--- a/app/views/user_verification/steps/show.html.erb
+++ b/app/views/user_verification/steps/show.html.erb
@@ -1,0 +1,1 @@
+<%= render 'form', current_step: current_step, wizard: wizard %>

--- a/config/initializers/date_formats.rb
+++ b/config/initializers/date_formats.rb
@@ -1,0 +1,4 @@
+# https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style#dates
+Date::DATE_FORMATS[:govuk]        = '%-d %B %Y' # 2 January 1998
+Date::DATE_FORMATS[:govuk_short]  = '%-d %b %Y' # 2 Jan 1998
+Date::DATE_FORMATS[:govuk_approx] = '%B %Y'     # January 1998

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,31 +1,27 @@
-# Files in the config/locales directory are used for internationalization and
-# are automatically loaded by Rails. If you want to use locales other than
-# English, add the necessary files in this directory.
-#
-# To use the locales, use `I18n.t`:
-#
-#     I18n.t "hello"
-#
-# In views, this is aliased to just `t`:
-#
-#     <%= t("hello") %>
-#
-# To use a different locale, set it with `I18n.locale`:
-#
-#     I18n.locale = :es
-#
-# This would use the information in config/locales/es.yml.
-#
-# To learn more about the API, please read the Rails Internationalization guide
-# at https://guides.rubyonrails.org/i18n.html.
-#
-# Be aware that YAML interprets the following case-insensitive strings as
-# booleans: `true`, `false`, `on`, `off`, `yes`, `no`. Therefore, these strings
-# must be quoted to be interpreted as strings. For example:
-#
-#     en:
-#       "yes": yup
-#       enabled: "ON"
-
 en:
-  hello: "Hello world"
+  fpo_usage_terms:
+    terms_hint_html: "Read the information below carefully. By ticking the boxes, you acknowledge that you have read, understood and agree to the %{terms_link}."
+    term1: "The Commodity Code Identification Tool is designated for backend operations only and must not be directly integrated into any customer-facing interfaces, applications, or websites"
+    term2: "Any access credentials are for the sole use of the UK Carrier Scheme (UKC) registered Fast Parcel Operator (FPO) to which they have been granted. They may be shared and used by third party suppliers but must only be used for the purposes of providing services to the FPO. It is the responsibility of the FPO to ensure that their suppliers adhere to these terms and that access credentials are kept confidential"
+    term3: "The API is only intended for generating commodity codes for parcels being transported from Great Britain to Northern Ireland that are classified as \"Not at Risk\" of onward movement out of Northern Ireland, where Northern Ireland is their final destination and place of use/consumption. This includes goods moved under the UK Carrier Scheme (UKC)"
+    term4: "I have read, understood and agree to the terms and conditions of the Commodity Code Identification Tool"
+
+  activemodel:
+    errors:
+      models:
+        user_verification/steps/details:
+          attributes:
+            organisation_name:
+              blank: "Enter the name of your organisation"
+            ukacs_reference:
+              blank: "Enter your UK Carrier Scheme (UKC) reference number"
+            eori_number:
+              blank: "Enter your EORI number"
+              invalid: "Enter a real EORI number"
+            email_address:
+              blank: "Enter your work email address"
+
+        user_verification/steps/review_answers:
+          attributes:
+            terms:
+              blank: "You must agree to all the terms & conditions by ticking the boxes"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,6 +1,21 @@
 en:
+  helpers:
+    label:
+      user_verification_steps_details:
+        organisation_name: "What is the name of your organisation?"
+        eori_number: "What is your EORI number?"
+        ukacs_reference: "What is your UK Carrier Scheme (UKC) reference number?"
+        email_address: "Your work email address"
+    hint:
+      user_verification_steps_details:
+        organisation_name: "This should be the name of the organisation you are accessing the Commodity Code Tool on behalf of."
+        eori_number: "Your organisation will have an Economic Operators Registration and Identification (EORI) number."
+        ukacs_reference: "Your organisation would have received a unique reference number when signing up for the UK Authorised Carrier Scheme."
+        email_address: "We will only use your email address to send essential updates regarding the Commodity Code Identification Tool and your verification request."
+      user_verification_steps_review_answers:
+        terms_html: "Read the information below carefully. By ticking the boxes, you acknowledge that you have read, understood and agree to the %{terms_link}."
+
   fpo_usage_terms:
-    terms_hint_html: "Read the information below carefully. By ticking the boxes, you acknowledge that you have read, understood and agree to the %{terms_link}."
     term1: "The Commodity Code Identification Tool is designated for backend operations only and must not be directly integrated into any customer-facing interfaces, applications, or websites"
     term2: "Any access credentials are for the sole use of the UK Carrier Scheme (UKC) registered Fast Parcel Operator (FPO) to which they have been granted. They may be shared and used by third party suppliers but must only be used for the purposes of providing services to the FPO. It is the responsibility of the FPO to ensure that their suppliers adhere to these terms and that access credentials are kept confidential"
     term3: "The API is only intended for generating commodity codes for parcels being transported from Great Britain to Northern Ireland that are classified as \"Not at Risk\" of onward movement out of Northern Ireland, where Northern Ireland is their final destination and place of use/consumption. This includes goods moved under the UK Carrier Scheme (UKC)"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,6 +20,14 @@ Rails.application.routes.draw do
     delete "dashboard/:id/delete", to: "api_keys#delete"
   end
 
+  namespace :user_verification do
+    resources :steps, only: %i[show update index] do
+      collection do
+        get :completed
+      end
+    end
+  end
+
   match "/400", to: "errors#bad_request", via: :all
   match "/404", to: "errors#not_found", via: :all, as: :not_found
   match "/405", to: "errors#method_not_allowed", via: :all

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,6 +24,7 @@ Rails.application.routes.draw do
     resources :steps, only: %i[show update index] do
       collection do
         get :completed
+        get :rejected
       end
     end
   end

--- a/spec/helpers/api_keys_helper_spec.rb
+++ b/spec/helpers/api_keys_helper_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe ApiKeysHelper, type: :helper do
     context "when disabled" do
       let(:enabled) { false }
 
-      it { is_expected.to eq("Revoked on #{api_key.updated_at.strftime('%d %B %Y')}") }
+      it { is_expected.to eq("Revoked on #{api_key.updated_at.to_date.to_formatted_s(:govuk)}") }
     end
   end
 

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -31,8 +31,8 @@ RSpec.describe ApplicationHelper, type: :helper do
     end
   end
 
-  describe "#fpo_usage_terms_hint" do
-    subject { helper.fpo_usage_terms_hint }
+  describe "#user_verification_steps_review_answers_terms_hint" do
+    subject { helper.user_verification_steps_review_answers_terms_hint }
 
     it { is_expected.to include("Read the information below carefully") }
     it { is_expected.to be_html_safe }

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,0 +1,40 @@
+RSpec.describe ApplicationHelper, type: :helper do
+  describe "#documentation_link" do
+    subject { helper.documentation_link }
+
+    it { is_expected.to include("/fpo.html") }
+    it { is_expected.to be_html_safe }
+  end
+
+  describe "#feedback_link" do
+    subject { helper.feedback_link }
+
+    it { is_expected.to include("/feedback") }
+    it { is_expected.to be_html_safe }
+  end
+
+  describe "#terms_link" do
+    subject { helper.terms_link }
+
+    it { is_expected.to include("/fpo/terms-and-conditions.html") }
+    it { is_expected.to be_html_safe }
+  end
+
+  describe "#fpo_usage_terms" do
+    subject(:terms) { helper.fpo_usage_terms }
+
+    it { is_expected.to all(be_a(Struct)) }
+    it { is_expected.to all(respond_to(:id, :text)) }
+
+    it "translates the terms correctly" do
+      expect(terms.map(&:text).first).to include("designated for backend operations only")
+    end
+  end
+
+  describe "#fpo_usage_terms_hint" do
+    subject { helper.fpo_usage_terms_hint }
+
+    it { is_expected.to include("Read the information below carefully") }
+    it { is_expected.to be_html_safe }
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -35,4 +35,20 @@ RSpec.describe User, type: :model do
       it { expect { from_profile! }.to change(Organisation, :count).by(1) }
     end
   end
+
+  describe "#application_reference" do
+    subject { user.application_reference }
+
+    let(:user) do
+      create(
+        :user,
+        organisation: create(
+          :organisation,
+          application_reference: "foo",
+        ),
+      )
+    end
+
+    it { is_expected.to eq("foo") }
+  end
 end

--- a/spec/models/user_verification/steps/details_spec.rb
+++ b/spec/models/user_verification/steps/details_spec.rb
@@ -1,0 +1,59 @@
+RSpec.describe UserVerification::Steps::Details, type: :model do
+  describe "validations" do
+    subject(:step) do
+      wizard = instance_double(UserVerification::Wizard, email_address: nil)
+      store = ::WizardSteps::Store.new({})
+
+      described_class.new(wizard, store, attributes)
+    end
+
+    let(:service) { instance_double(CheckEoriNumber, call: result) }
+
+    let(:attributes) do
+      {
+        organisation_name: "Flibble Exteriors",
+        eori_number: "GB12345678",
+        ukacs_reference: "XIUK134123213123",
+        email_address: "foo@bar.com",
+      }
+    end
+
+    let(:result) { true }
+
+    before do
+      allow(CheckEoriNumber).to receive(:new).and_return(service)
+    end
+
+    it { is_expected.to be_valid }
+
+    context "when the eori_number is not a real eori number" do
+      let(:result) { false }
+
+      it { is_expected.not_to be_valid }
+    end
+
+    context "when organisation_name is blank" do
+      before { attributes.delete(:organisation_name) }
+
+      it { is_expected.not_to be_valid }
+    end
+
+    context "when eori_number is blank" do
+      before { attributes.delete(:eori_number) }
+
+      it { is_expected.not_to be_valid }
+    end
+
+    context "when ukacs_reference is blank" do
+      before { attributes.delete(:ukacs_reference) }
+
+      it { is_expected.not_to be_valid }
+    end
+
+    context "when email_address is blank" do
+      before { attributes.delete(:email_address) }
+
+      it { is_expected.not_to be_valid }
+    end
+  end
+end

--- a/spec/models/user_verification/steps/review_answers_spec.rb
+++ b/spec/models/user_verification/steps/review_answers_spec.rb
@@ -1,0 +1,28 @@
+RSpec.describe UserVerification::Steps::ReviewAnswers, type: :model do
+  describe "validations" do
+    subject(:step) do
+      wizard = instance_double(UserVerification::Wizard, email_address: nil)
+      store = ::WizardSteps::Store.new({})
+
+      described_class.new(wizard, store, attributes)
+    end
+
+    let(:attributes) do
+      {
+        terms: ["", "1", "2", "3", "4"],
+      }
+    end
+
+    it { is_expected.to be_valid }
+
+    context "when the one or more of the terms is not checked" do
+      let(:attributes) do
+        {
+          terms: ["", "1", "2", "4"],
+        }
+      end
+
+      it { is_expected.not_to be_valid }
+    end
+  end
+end

--- a/spec/models/user_verification/wizard_spec.rb
+++ b/spec/models/user_verification/wizard_spec.rb
@@ -1,0 +1,55 @@
+RSpec.describe UserVerification::Wizard, type: :model do
+  subject(:wizard) do
+    store = ::WizardSteps::Store.new(store_answers)
+
+    described_class.new(store, current_key, context:)
+  end
+
+  let(:context) do
+    {
+      email_address: "foo@bar.com",
+      current_user: current_user,
+    }
+  end
+
+  let(:current_user) { create(:user, email_address: "baz@qux.com", organisation:) }
+  let(:current_key) { "review_answers" }
+  let(:organisation) { create(:organisation, application_reference: "foo") }
+
+  let(:store_answers) do
+    {
+      "organisation_name" => "Flibble Exteriors",
+      "eori_number" => "GB12345678",
+      "ukacs_reference" => "XIUK134123213123",
+      "email_address" => "foo@bar.com",
+    }
+  end
+
+  describe "#email_address" do
+    it { expect(wizard.email_address).to eq("foo@bar.com") }
+  end
+
+  describe "#current_user" do
+    it { expect(wizard.current_user).to eq(current_user) }
+  end
+
+  describe "#do_complete" do
+    context "when the organisation already has an application reference" do
+      let(:organisation) { create(:organisation, application_reference: "foo") }
+
+      it { expect(wizard.do_complete).to eq("foo") }
+      it { expect { wizard.do_complete }.not_to(change { organisation.reload.status }) }
+    end
+
+    context "when the organisation does not yet have an application reference" do
+      let(:organisation) { create(:organisation, application_reference: nil, status: :unregistered) }
+
+      it { expect { wizard.do_complete }.to(change { organisation.reload.application_reference }) }
+      it { expect { wizard.do_complete }.to change { organisation.reload.eori_number }.to("GB12345678") }
+      it { expect { wizard.do_complete }.to change { organisation.reload.status }.from("unregistered").to("pending") }
+      it { expect { wizard.do_complete }.to change { organisation.reload.uk_acs_reference }.to("XIUK134123213123") }
+      it { expect { wizard.do_complete }.to change { organisation.reload.organisation_name }.to("Flibble Exteriors") }
+      it { expect { wizard.do_complete }.to change { current_user.reload.email_address }.to("foo@bar.com") }
+    end
+  end
+end

--- a/spec/services/check_eori_number_spec.rb
+++ b/spec/services/check_eori_number_spec.rb
@@ -1,0 +1,22 @@
+RSpec.describe CheckEoriNumber do
+  describe "#call" do
+    subject { described_class.new(client).call("GB1234567890") }
+
+    let(:client) { instance_double(Faraday::Connection, post: response) }
+    let(:response) { instance_double(Faraday::Response, status: status) }
+
+    before { allow(Faraday).to receive(:new).and_return(client) }
+
+    context "when the client returns a 200 status" do
+      let(:status) { 200 }
+
+      it { is_expected.to be true }
+    end
+
+    context "when the client returns a non-200 status" do
+      let(:status) { 400 }
+
+      it { is_expected.to be false }
+    end
+  end
+end


### PR DESCRIPTION
# Jira link

[HMRC-877](https://transformuk.atlassian.net/browse/HMRC-877)

Rejected
![image](https://github.com/user-attachments/assets/aaa28f49-61fd-402e-862b-7ce67cbf0d6b)

Pending
![image](https://github.com/user-attachments/assets/caa76900-bb38-426e-b975-1bb561f9ed23)

Details page
![image](https://github.com/user-attachments/assets/e529efa1-e105-427f-8485-79def0667569)

Review answers page
![image](https://github.com/user-attachments/assets/7aef58da-e039-4080-880a-45a9d0f65599)

## What?

I have:

- Adds verification wizard
- Adds hook to require registration of new users
- Adds rejected and completed registration state handling
- Adds service to validate the EORI number input by the user

## Why?

I am doing this because:

- This is needed to capture user registration inputs
