### PR TITLE
HMRC-1035: Adds privacy and cookies pages

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,0 +1,4 @@
+class PagesController < ApplicationController
+  def cookies; end
+  def privacy; end
+end

--- a/app/views/homepage/index.html.erb
+++ b/app/views/homepage/index.html.erb
@@ -6,27 +6,30 @@
       <%= carrier_scheme_inset_text %>
 
       <p class="govuk-body">You can use this service to:</p>
-      <ul class="govuk-list govuk-list--bullet">
-          <li>create an API key for yourself</li>
-          <li>create an API key for someone else in your organisation</li>
-          <li>revoke an API key</li>
-          <li>view active API keys</li>
-      </ul>
+      <%= govuk_list [
+        "create an API key for yourself",
+        "create an API key for someone else in your organisation",
+        "revoke an API key",
+        "view active API keys",
+      ], type: :bullet %>
+
       <p class="govuk-body">
           You'll need a Government Gateway account to use this service. If you do not have a Government Gateway account, you can create one.
       </p>
+
       <p class="govuk-body">If it is your first time registering, you'll also need:</p>
-      <ul class="govuk-list govuk-list--bullet">
-          <li>the name of your organisation</li>
-          <li>the EORI number of your organisation</li>
-          <li>the UK Authorised Carrier Scheme reference number of your organisation</li>
-          <li>an email address for essential updates</li>
-      </ul>
+      <%= govuk_list [
+        "the name of your organisation",
+        "the EORI number of your organisation",
+        "the UK Authorised Carrier Scheme reference number of your organisation",
+        "an email address for essential updates",
+      ], type: :bullet %>
+
       <%= govuk_start_button(text: "Start now", href: "/dashboard") %>
+
       <h2 class="govuk-heading-m">If you need help</h2>
       <p class="govuk-body">
-          If you have any further queries relating to the developer hub contact: <a class="govuk-link"
-  href="mailto:hmrc-trade-tariff-support-g@digital.hmrc.gov.uk">hmrc-trade-tariff-support-g@digital.hmrc.gov.uk</a>
+          If you have any further queries relating to the developer hub contact: <%= govuk_link_to "hmrc-trade-tariff-support-g@digital.hmrc.gov.uk", "mailto:hmrc-trade-tariff-support-g@digital.hmrc.gov.uk" %>
       </p>
     </div>
 </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -45,8 +45,8 @@
   <%= govuk_footer(meta_items_title: "Helpful links", meta_items: {
     "API Documentation" => TradeTariffDevHub.documentation_url,
     "Feedback" =>  TradeTariffDevHub.feedback_url,
-    "Privacy policy" => "https://hub.trade-tariff.service.gov.uk/privacyPolicy",
-    "Cookies" => "#",
+    "Privacy policy" => privacy_path,
+    "Cookies" => cookies_path,
     "Terms and conditions" => TradeTariffDevHub.terms_and_conditions_url,
   }) %>
 </html>

--- a/app/views/pages/cookies.html.erb
+++ b/app/views/pages/cookies.html.erb
@@ -6,8 +6,6 @@
 <p class="govuk-body">These essential cookies do things like remember your progress through the application. They always need to be on, or the service will not function.</p>
 
 <%= govuk_table do |table|
-  table.with_caption(size: 'm', text: 'List of Pokémon generations')
-
   table.with_head do |head|
     head.with_row do |row|
       row.with_cell(header: true, text: 'Name')

--- a/app/views/pages/cookies.html.erb
+++ b/app/views/pages/cookies.html.erb
@@ -1,0 +1,40 @@
+<h1 class="govuk-heading-xl">Cookies on the Commodity Code Identification Tool Developer Hub</h1>
+<p class="govuk-body">Cookies are files saved on your phone, tablet or computer when you visit a website. We use cookies to store information about how you use this website, such as the pages you visit.</p>
+
+<h2 class="govuk-heading-m">Strictly necessary cookies</h2>
+<p class="govuk-body">We only use strictly necessary cookies.</p>
+<p class="govuk-body">These essential cookies do things like remember your progress through the application. They always need to be on, or the service will not function.</p>
+
+<%= govuk_table do |table|
+  table.with_caption(size: 'm', text: 'List of Pokémon generations')
+
+  table.with_head do |head|
+    head.with_row do |row|
+      row.with_cell(header: true, text: 'Name')
+      row.with_cell(header: true, text: 'Purpose')
+      row.with_cell(header: true, text: 'Expires')
+    end
+  end
+
+  table.with_body do |body|
+    body.with_row do |row|
+      row.with_cell(text: 'session')
+      row.with_cell(text: 'Stores details about your current login session')
+      row.with_cell(text: 'When you close your browser')
+    end
+
+    body.with_row do |row|
+      row.with_cell(text: 'session_sig')
+      row.with_cell(text: "Stores a digital signature to ensure that the 'session' cookie hasn't been altered")
+      row.with_cell(text: 'When you close your browser')
+    end
+
+    body.with_row do |row|
+      row.with_cell(text: 'appSession.0, appSession.1, etc.')
+      row.with_cell(text: "Temporarily stores any information you provide while completing forms within the site")
+      row.with_cell(text: 'When you close your browser')
+    end
+  end
+end %>
+
+<p class="govuk-body">Last updated 21 June 2024</p>

--- a/app/views/pages/privacy.html.erb
+++ b/app/views/pages/privacy.html.erb
@@ -1,0 +1,168 @@
+<h1 class="govuk-heading-xl">Privacy notice</h1>
+
+<p class="govuk-body">
+  Commodity Code Identification Tool Developer Hub (the ‘service’) is provided by HM Revenue and Customs (HMRC). HMRC will be referred to as ‘we’ or ‘us’ throughout this notice.
+</p>
+
+<p class="govuk-body">We are committed to protecting the privacy and security of your personal information.</p>
+
+<h2 class="govuk-heading-m">The purpose of this notice</h2>
+
+<p class="govuk-body">
+  This privacy notice describes how we collect and use personal information about you in accordance with data protection law, including the UK General Data Protection Regulation (UK GDPR) and the Data Protection Act (DPA) 2018.
+</p>
+
+<h2 class="govuk-heading-m">What data we collect</h2>
+
+<p class="govuk-body">For use of the service:</p>
+
+<ul class="govuk-list govuk-list--bullet">
+  <li>The name and email address you used to sign up to Government Gateway</li>
+</ul>
+
+<p class="govuk-body">To register for the FPO commodity code identification API:</p>
+
+<ul class="govuk-list govuk-list--bullet">
+  <li>Your organisation name</li>
+  <li>Your work email address</li>
+</ul>
+
+<p class="govuk-body">For online and telephone support:</p>
+
+<ul class="govuk-list govuk-list--bullet">
+  <li>name</li>
+  <li>email address</li>
+  <li>telephone number</li>
+  <li>details of your support issue</li>
+</ul>
+
+<h2 class="govuk-heading-m">Why we collect your personal data</h2>
+
+<p class="govuk-body">We collect your personal data to:</p>
+
+<ul class="govuk-list govuk-list--bullet">
+  <li>allow you to access the service securely</li>
+  <li>allow us to contact you regarding an application to access the FPO commodity code identification tool API</li>
+  <li>allow us to notify you about any siginificant changes to the service availability such as planned outages</li>
+  <li>gather feedback to improve the service</li>
+  <li>respond to any feedback you send us, if you have asked us to</li>
+</ul>
+
+<h2 class="govuk-heading-m">The legal basis of using your data</h2>
+
+<p class="govuk-body">In order for the use of personal data to be lawful, we need to meet one (or more) conditions in the data protection legislation, as set out in Article 6(1) of the General Data Protection Regulation (GDPR).</p>
+
+<p class="govuk-body">For the purpose of providing the Commodity Code Identification Tool Developer Hub, the relevant condition that we are meeting is ‘public task’ as specified under Article 6 (1)(e) of the GDPR.</p>
+
+<h2 class="govuk-heading-m">Who we share your data with</h2>
+
+<p class="govuk-body">Your personal data will be shared with our third party suppliers who provide the service.</p>
+
+<h2 class="govuk-heading-m">Data security</h2>
+
+<p class="govuk-body">We have put in place measures to protect the security of your information.</p>
+
+<p class="govuk-body">
+  Our third-party service providers will only process your personal information on our instructions or with our agreement,
+  and where they have agreed to treat the information confidentially and to keep it secure.
+</p>
+
+<p class="govuk-body">
+  We treat the security of your data very seriously. We have strict security standards, and all our staff and other people who process personal data on our behalf get regular training about how to keep information safe.
+</p>
+
+<p class="govuk-body">
+  We have put in place appropriate technical, physical and managerial procedures to safeguard and secure the information we collect about you.
+</p>
+
+<p class="govuk-body">
+  In addition, we limit access to your personal information to those persons, or agents who have a business or legal need to do so.
+</p>
+
+<p class="govuk-body">
+  We have taken measures to make sure an adequate level of security for personal information processed via our website.
+</p>
+<p class="govuk-body">
+  We have put in place procedures to deal with any suspected data security breach and will notify you and the regulator of a suspected breach where we are legally required to do so.
+</p>
+
+<h2 class="govuk-heading-m">Data retention</h2>
+
+<p class="govuk-body">
+  Your personal data will be kept by us for as long as needed to provide you with the service.
+</p>
+
+<h2 class="govuk-heading-m">Your rights</h2>
+
+<p class="govuk-body">You have the right to request:</p>
+
+<ul class="govuk-list govuk-list--bullet">
+  <li>information about how your personal data is processed</li>
+  <li>a copy of that personal data</li>
+  <li>that anything inaccurate in your personal data is corrected immediately</li>
+</ul>
+
+<p class="govuk-body">You can also:</p>
+
+<ul class="govuk-list govuk-list--bullet">
+  <li>raise an objection about how your personal data is processed</li>
+  <li>request that your personal data is erased if there is no longer a justification for it</li>
+  <li>ask that the processing of your personal data is restricted in certain circumstances</li>
+  <li>If you have any of these requests, get in contact with our Privacy Team.</li>
+</ul>
+
+<h2 class="govuk-heading-m">International transfers</h2>
+
+<p class="govuk-body">
+  We design, build and run our systems to make sure that your data is as safe as possible at all stages, both while it’s processed and when it’s stored.
+</p>
+
+<p class="govuk-body">All personal data is stored in the European Economic Area (EEA).</p>
+
+<h2 class="govuk-heading-m">Complaints</h2>
+
+<p class="govuk-body">
+  HMRC has appointed a Data Protection Officer (<abbr title="Data Protection Officer">DPO</abbr>), Nicholas de Lacy-Brown, to oversee compliance with its data protection obligations.
+</p>
+
+<p class="govuk-body">
+  If you have any questions about this privacy notice or how HMRC handles your personal information, email the <abbr title="Data Protection Officer">DPO</abbr>
+at: <%= govuk_link_to "advice.dpa@hmrc.gov.uk", "mailto:advice.dpa@hmrc.gov.uk" %>
+</p>
+
+<p class="govuk-body">
+  You can read more about how the <abbr title="Data Protection Officer">DPO</abbr> handles your personal information in our <%= govuk_link_to "Office of the Data Protection Officer Privacy Notice", "https://www.gov.uk/government/publications/hmrc-office-of-the-data-protection-officer-privacy-notice" %>
+</p>
+
+<p class="govuk-body">
+  If you want to request a copy of your personal data follow HMRC’s <%= govuk_link_to "subject access request guidance", "https://www.gov.uk/guidance/hmrc-subject-access-request" %>.
+</p>
+
+<p class="govuk-body">
+  You should follow the existing complaints process if you want to <%= govuk_link_to "complain about HMRC", "https://www.gov.uk/government/organisations/hm-revenue-customs/contact/complain-about-hmrc" %>
+</p>
+
+<p class="govuk-body">
+  You also have the right to make a complaint at any time to the Information Commissioner’s Office (<abbr title="Information Commissioner">ICO</abbr>), the UK supervisory authority for data protection issues.
+</p>
+
+<p class="govuk-body">
+  If you consider that your personal data has been misused or mishandled, you may make a complaint to the Information Commissioner, who is an independent regulator.
+</p>
+
+<p class="govuk-body">The Information Commissioner can be contacted at:</p>
+
+<p class="govuk-body">
+  Information Commissioner's Office<br>
+  Wycliffe House<br>
+  Water Lane<br>
+  Wilmslow<br>
+  Cheshire SK9 5AF<br>
+  <br>
+  Telephone: 0303 123 1113<br>
+  Email: <%= govuk_link_to "casework@ico.org.uk", "mailto:casework@ico.org.uk", rel: "noopener noreferrer" %>
+</p>
+
+<p class="govuk-body">
+  Any complaint to the Information Commissioner is without prejudice to your right to seek redress through the courts.
+</p>

--- a/app/views/pages/privacy.html.erb
+++ b/app/views/pages/privacy.html.erb
@@ -16,37 +16,37 @@
 
 <p class="govuk-body">For use of the service:</p>
 
-<ul class="govuk-list govuk-list--bullet">
-  <li>The name and email address you used to sign up to Government Gateway</li>
-</ul>
+<%= govuk_list [
+  "The name and email address you used to sign up to Government Gateway",
+], type: :bullet %>
 
 <p class="govuk-body">To register for the FPO commodity code identification API:</p>
 
-<ul class="govuk-list govuk-list--bullet">
-  <li>Your organisation name</li>
-  <li>Your work email address</li>
-</ul>
+<%= govuk_list [
+  "Your organisation name",
+  "Your work email address",
+], type: :bullet %>
 
 <p class="govuk-body">For online and telephone support:</p>
 
-<ul class="govuk-list govuk-list--bullet">
-  <li>name</li>
-  <li>email address</li>
-  <li>telephone number</li>
-  <li>details of your support issue</li>
-</ul>
+<%= govuk_list [
+  "name",
+  "email address",
+  "telephone number",
+  "details of your support issue",
+], type: :bullet %>
 
 <h2 class="govuk-heading-m">Why we collect your personal data</h2>
 
 <p class="govuk-body">We collect your personal data to:</p>
 
-<ul class="govuk-list govuk-list--bullet">
-  <li>allow you to access the service securely</li>
-  <li>allow us to contact you regarding an application to access the FPO commodity code identification tool API</li>
-  <li>allow us to notify you about any siginificant changes to the service availability such as planned outages</li>
-  <li>gather feedback to improve the service</li>
-  <li>respond to any feedback you send us, if you have asked us to</li>
-</ul>
+<%= govuk_list [
+  "allow you to access the service securely",
+  "allow us to contact you regarding an application to access the FPO commodity code identification tool API",
+  "allow us to notify you about any siginificant changes to the service availability such as planned outages",
+  "gather feedback to improve the service",
+  "respond to any feedback you send us, if you have asked us to",
+], type: :bullet %>
 
 <h2 class="govuk-heading-m">The legal basis of using your data</h2>
 
@@ -96,20 +96,20 @@
 
 <p class="govuk-body">You have the right to request:</p>
 
-<ul class="govuk-list govuk-list--bullet">
-  <li>information about how your personal data is processed</li>
-  <li>a copy of that personal data</li>
-  <li>that anything inaccurate in your personal data is corrected immediately</li>
-</ul>
+<%= govuk_list [
+  "information about how your personal data is processed",
+  "a copy of that personal data",
+  "that anything inaccurate in your personal data is corrected immediately",
+], type: :bullet %>
 
 <p class="govuk-body">You can also:</p>
 
-<ul class="govuk-list govuk-list--bullet">
-  <li>raise an objection about how your personal data is processed</li>
-  <li>request that your personal data is erased if there is no longer a justification for it</li>
-  <li>ask that the processing of your personal data is restricted in certain circumstances</li>
-  <li>If you have any of these requests, get in contact with our Privacy Team.</li>
-</ul>
+<%= govuk_list [
+  "raise an objection about how your personal data is processed",
+  "request that your personal data is erased if there is no longer a justification for it",
+  "ask that the processing of your personal data is restricted in certain circumstances",
+  "If you have any of these requests, get in contact with our Privacy Team.",
+], type: :bullet %>
 
 <h2 class="govuk-heading-m">International transfers</h2>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,8 +29,8 @@ Rails.application.routes.draw do
     end
   end
 
-  get :privacy, to: "pages#privacy", as: :privacy
-  get :cookies, to: "pages#cookies", as: :cookies
+  get :privacy, to: "pages#privacy"
+  get :cookies, to: "pages#cookies"
 
   match "/400", to: "errors#bad_request", via: :all
   match "/404", to: "errors#not_found", via: :all, as: :not_found

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,6 +29,9 @@ Rails.application.routes.draw do
     end
   end
 
+  get :privacy, to: "pages#privacy", as: :privacy
+  get :cookies, to: "pages#cookies", as: :cookies
+
   match "/400", to: "errors#bad_request", via: :all
   match "/404", to: "errors#not_found", via: :all, as: :not_found
   match "/405", to: "errors#method_not_allowed", via: :all


### PR DESCRIPTION
# Jira link

[HMRC-1035](https://transformuk.atlassian.net/browse/HMRC-1035)

![image](https://github.com/user-attachments/assets/cccda02d-0dc5-4de3-8d3d-37d7c783b454)
![image](https://github.com/user-attachments/assets/9adf54b7-9e0a-4f17-9b81-28a0aa1536e6)


## What?

I have:

- [x] Added a cookies page
- [x] Added a privacy page

## Why?

I am doing this because:

- These are needed for completeness/legal reasons
