### PR TITLE
HMRC-1036: Expire session when Government Gateway tells us too

### DIFF
--- a/app/controllers/authenticated_controller.rb
+++ b/app/controllers/authenticated_controller.rb
@@ -5,10 +5,13 @@ class AuthenticatedController < ApplicationController
                 :require_registration,
                 :set_paper_trail_whodunnit
 
+protected
+
   def require_authentication
     return if current_user.present?
     return unless TradeTariffDevHub.scp_enabled?
 
+    handle_session_expiry
     redirect_to "/auth/openid_connect"
   end
 
@@ -18,6 +21,14 @@ class AuthenticatedController < ApplicationController
     redirect_to user_verification_steps_path if organisation.unregistered?
     redirect_to completed_user_verification_steps_path if organisation.pending?
     redirect_to rejected_user_verification_steps_path if organisation.rejected?
+  end
+
+  def handle_session_expiry
+    return if session_expired?
+
+    session[:user_id] = nil
+    session[:organisation_id] = nil
+    session[:user_profile] = nil
   end
 
   def user_profile
@@ -46,6 +57,16 @@ class AuthenticatedController < ApplicationController
 
   def update_profile_url
     user_profile["profile"].to_s + "?redirect_uri=#{profile_redirect_url}"
+  end
+
+  def session_expired?
+    return true if session[:user_profile].blank?
+
+    expires_at < Time.zone.now.to_i
+  end
+
+  def expires_at
+    session[:user_profile]["exp"].to_i
   end
 
   helper_method :current_user, :organisation, :manage_team_url, :update_profile_url


### PR DESCRIPTION
# Jira link

[HMRC-1036](https://transformuk.atlassian.net/browse/HMRC-1036)

## What?

I have:

- [x] Added session expiration handling

## Why?

I am doing this because:

- This is needed to we don't give users access to resources when the user's session in SCP has expired
