### PR TITLE
HMRC-1047: Adds handling for non-organisation accounts

### DIFF
--- a/app/controllers/authenticated_controller.rb
+++ b/app/controllers/authenticated_controller.rb
@@ -69,5 +69,9 @@ protected
     session[:user_profile]["exp"].to_i
   end
 
-  helper_method :current_user, :organisation, :manage_team_url, :update_profile_url
+  def organisation_account?
+    manage_team_url.present?
+  end
+
+  helper_method :current_user, :organisation, :manage_team_url, :update_profile_url, :organisation_account?
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -11,6 +11,13 @@ module ApplicationHelper
     govuk_link_to "terms and conditions of the Commodity Code Identification Tool (opens in new tab)", TradeTariffDevHub.terms_and_conditions_url, target: "_blank", rel: "noopener noreferrer"
   end
 
+  def carrier_scheme_link
+    govuk_link_to "apply for the UK Carrier scheme here (opens in new tab)",
+                  "https://www.gov.uk/guidance/apply-for-the-uk-carrier-scheme",
+                  target: "_blank",
+                  rel: "noopener noreferrer"
+  end
+
   def fpo_usage_terms
     option = Struct.new(:id, :text)
     range = (1..4)
@@ -24,5 +31,9 @@ module ApplicationHelper
 
   def user_verification_steps_review_answers_terms_hint
     t("helpers.hint.user_verification_steps_review_answers.terms_html", terms_link: terms_link)
+  end
+
+  def carrier_scheme_inset_text
+    govuk_inset_text text: "To use this service, your organisation must be UK Carrier Scheme (UKC) registered. You can #{carrier_scheme_link}".html_safe
   end
 end

--- a/app/views/homepage/index.html.erb
+++ b/app/views/homepage/index.html.erb
@@ -2,12 +2,9 @@
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-xl">Commodity Code Identification Tool Developer Hub</h1>
       <p class="govuk-body">This service allows you to create API keys to access the FPO Commodity Code Identification Tool API</p>
-      <div class="govuk-inset-text">
-        To use this service, your organisation must be UK Carrier Scheme (UKC) registered. You can
-        <a href="https://www.gov.uk/guidance/apply-for-the-uk-carrier-scheme" target="_blank">
-          apply for the UK Carrier scheme here (opens in new tab)
-        </a>.
-      </div>
+
+      <%= carrier_scheme_inset_text %>
+
       <p class="govuk-body">You can use this service to:</p>
       <ul class="govuk-list govuk-list--bullet">
           <li>create an API key for yourself</li>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -24,7 +24,7 @@
     if respond_to?(:current_user) && current_user.present?
       header.with_navigation_item(text: "Dashboard", href: api_keys_path, active: true)
       header.with_navigation_item(text: "Update Profile", href: update_profile_url, active: false)
-      header.with_navigation_item(text: "Manage Team", href: manage_team_url, active: false)
+      header.with_navigation_item(text: "Manage Team", href: manage_team_url, active: false) if organisation_account?
       header.with_navigation_item(text: "Sign Out", href: logout_path, active: false)
     end
   end %>

--- a/app/views/user_verification/steps/_form.html.erb
+++ b/app/views/user_verification/steps/_form.html.erb
@@ -1,3 +1,15 @@
+<% unless organisation_account? %>
+    <%= govuk_notification_banner(title_text: "It looks like you're using a personal Government Gateway account")  do %>
+        <p class="govuk-body">
+            If you register using this account you won't be able to invite other users to manage the API keys for this organisation.
+        </p>
+
+        <p class="govuk-body">
+            You can <%= govuk_link_to "sign out", logout_path  %> and create a new Government Gateway account, or use an existing one, for your organisation.
+        </p>
+    <% end %>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_for current_step, url: user_verification_step_path(current_step.key) do |f| %>


### PR DESCRIPTION
# Jira link

[HMRC-1047](https://transformuk.atlassian.net/browse/HMRC-1047)

![image](https://github.com/user-attachments/assets/ce29802f-a62d-4508-b18f-fa2102610829)

## What?

I have:

- [x] Added notification banner for non-organisation account
- [x] Refactored carrier_scheme inset into helper

## Why?

I am doing this because:

- This is needed to communicate that we're expecting people to be using an organisation account
