### PR TITLE
HMRC-1166: Support server side sessions for logout

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ gem "rails"
 
 gem "aws-sdk-apigateway"
 gem "aws-sdk-dynamodb"
+gem "hashie"
 gem "importmap-rails"
 gem "ostruct"
 gem "paper_trail"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -458,6 +458,7 @@ DEPENDENCIES
   factory_bot_rails
   govuk-components
   govuk_design_system_formbuilder
+  hashie
   importmap-rails
   notifications-ruby-client
   omniauth-rails_csrf_protection

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,35 +1,56 @@
+# frozen_string_literal: true
+
 class SessionsController < ApplicationController
   skip_before_action :verify_authenticity_token, only: :handle_redirect
 
   def handle_redirect
-    user = User.from_profile!(raw_info)
-
-    session[:user_id] = user.id
-    session[:organisation_id] = user.organisation_id
-    session[:user_profile] = raw_info
+    create_user_session!
+    session[:token] = session_token
 
     redirect_to api_keys_path
   rescue StandardError => e
     Rails.logger.error("Authentication error: #{e.message}")
-    redirect_to root_path
+    redirect_to root_path, alert: "Authentication failed. Please try again."
   end
 
   def failure
     Rails.logger.error("Authentication failure: #{request.env['omniauth.error']}")
-    redirect_to root_path
+    redirect_to root_path, alert: "Authentication failed. Please try again."
   end
 
   def destroy
-    session[:user_id] = nil
-    session[:organisation_id] = nil
+    user_session&.destroy!
+
     session[:user_profile] = nil
+    session[:token] = nil
 
     redirect_to "/auth/openid_connect/logout"
   end
 
 private
 
+  def create_user_session!
+    Session.create!(
+      user: user,
+      token: session_token,
+      expires_at: Time.zone.at(raw_info.exp.to_i),
+      raw_info: raw_info.as_json,
+    )
+  end
+
   def raw_info
     @raw_info ||= request.env["omniauth.auth"].extra.raw_info
+  end
+
+  def session_token
+    @session_token ||= SecureRandom.uuid
+  end
+
+  def user
+    @user ||= User.from_profile!(raw_info)
+  end
+
+  def user_session
+    Session.find_by(token: session[:token])
   end
 end

--- a/app/controllers/user_verification/steps_controller.rb
+++ b/app/controllers/user_verification/steps_controller.rb
@@ -19,7 +19,7 @@ module UserVerification
 
     def wizard_context
       {
-        email_address: user_profile["email"],
+        email_address: user_session.email_address,
         current_user: current_user,
       }
     end

--- a/app/helpers/authenticated_sessions_helper.rb
+++ b/app/helpers/authenticated_sessions_helper.rb
@@ -1,0 +1,13 @@
+module AuthenticatedSessionsHelper
+  def manage_team_url
+    return if user_session.manage_team_url.blank?
+
+    user_session.manage_team_url + "?redirect_uri=#{group_redirect_url}"
+  end
+
+  def update_profile_url
+    return if user_session.update_profile_url.blank?
+
+    user_session.update_profile_url + "?redirect_uri=#{profile_redirect_url}"
+  end
+end

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -2,6 +2,7 @@ class Organisation < ApplicationRecord
   has_paper_trail
 
   has_many :users, dependent: :destroy
+  has_many :api_keys, dependent: :destroy
 
   enum :status, {
     unregistered: 0,

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -1,0 +1,31 @@
+class Session < ApplicationRecord
+  belongs_to :user
+
+  validates :token, presence: true, uniqueness: true
+  validates :expires_at, presence: true
+  validates :raw_info, presence: true
+
+  def raw_info
+    Hashie::Mash.new(super || {})
+  end
+
+  def update_profile_url
+    raw_info.profile.to_s
+  end
+
+  def manage_team_url
+    raw_info["bas:groupProfile"].to_s
+  end
+
+  def email_address
+    raw_info.email.to_s
+  end
+
+  def organisation_account?
+    manage_team_url.present?
+  end
+
+  def expired?
+    expires_at < Time.zone.now
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,6 +2,7 @@ class User < ApplicationRecord
   has_paper_trail
 
   belongs_to :organisation
+  has_many :sessions, dependent: :destroy
 
   delegate :status, :application_reference, to: :organisation
 

--- a/app/views/application/_flashes.html.erb
+++ b/app/views/application/_flashes.html.erb
@@ -1,0 +1,27 @@
+<div class="flashes">
+  <% if notice %>
+    <div class="govuk-notification-banner govuk-notification-banner--success" role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+      <div class="govuk-notification-banner__header">
+        <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
+          Success
+        </h2>
+      </div>
+      <div class="govuk-notification-banner__content">
+        <p><%= notice %></p>
+      </div>
+    </div>
+  <% end %>
+
+  <% if alert %>
+    <div class="govuk-notification-banner govuk-notification-banner--error" role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+      <div class="govuk-notification-banner__header">
+        <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
+          Error
+        </h2>
+      </div>
+      <div class="govuk-notification-banner__content">
+        <p><%= alert %></p>
+      </div>
+    </div>
+  <% end %>
+</div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -24,7 +24,7 @@
     if respond_to?(:current_user) && current_user.present?
       header.with_navigation_item(text: "Dashboard", href: api_keys_path, active: true)
       header.with_navigation_item(text: "Update Profile", href: update_profile_url, active: false)
-      header.with_navigation_item(text: "Manage Team", href: manage_team_url, active: false) if organisation_account?
+      header.with_navigation_item(text: "Manage Team", href: manage_team_url, active: false) if user_session.organisation_account?
       header.with_navigation_item(text: "Sign Out", href: logout_path, active: false)
     end
   end %>
@@ -37,6 +37,7 @@
       will help us improve it.
     <% end %>
     <main class="govuk-main-wrapper app-main-class" id="main-content">
+      <%= render 'flashes' %>
       <%= yield %>
     </main>
   </div>

--- a/app/views/user_verification/steps/_form.html.erb
+++ b/app/views/user_verification/steps/_form.html.erb
@@ -1,4 +1,4 @@
-<% unless organisation_account? %>
+<% unless user_session.organisation_account? %>
     <%= govuk_notification_banner(title_text: "It looks like you're using a personal Government Gateway account")  do %>
         <p class="govuk-body">
             If you register using this account you won't be able to invite other users to manage the API keys for this organisation.

--- a/db/migrate/20250603084905_create_sessions.rb
+++ b/db/migrate/20250603084905_create_sessions.rb
@@ -1,0 +1,14 @@
+class CreateSessions < ActiveRecord::Migration[8.0]
+  def change
+    create_table :sessions, id: :uuid do |t|
+      # Session token to validate sessions server-side and prevent replay attacks
+      t.string :token, null: false, index: { unique: true }
+
+      t.references :user, null: false, foreign_key: true, type: :uuid
+      t.datetime :expires_at, null: false
+      t.jsonb :raw_info, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_03_12_092224) do
+ActiveRecord::Schema[8.0].define(version: 2025_06_03_084905) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pgcrypto"
@@ -42,6 +42,17 @@ ActiveRecord::Schema[8.0].define(version: 2025_03_12_092224) do
     t.index ["organisation_id"], name: "index_organisations_on_organisation_id", unique: true
   end
 
+  create_table "sessions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "token", null: false
+    t.uuid "user_id", null: false
+    t.datetime "expires_at", null: false
+    t.jsonb "raw_info", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["token"], name: "index_sessions_on_token", unique: true
+    t.index ["user_id"], name: "index_sessions_on_user_id"
+  end
+
   create_table "users", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "organisation_id", null: false
     t.string "email_address"
@@ -63,5 +74,6 @@ ActiveRecord::Schema[8.0].define(version: 2025_03_12_092224) do
   end
 
   add_foreign_key "api_keys", "organisations"
+  add_foreign_key "sessions", "users"
   add_foreign_key "users", "organisations"
 end

--- a/spec/factories/organisation.rb
+++ b/spec/factories/organisation.rb
@@ -1,5 +1,6 @@
 FactoryBot.define do
   factory :organisation do
+    authorised
     organisation_id { "MyString" }
     application_reference { "MyString" }
     description { "MyString" }
@@ -7,5 +8,21 @@ FactoryBot.define do
     organisation_name { "MyString" }
     status { 1 }
     uk_acs_reference { "MyString" }
+
+    trait :unregistered do
+      status { :unregistered }
+    end
+
+    trait :authorised do
+      status { :authorised }
+    end
+
+    trait :pending do
+      status { :pending }
+    end
+
+    trait :rejected do
+      status { :rejected }
+    end
   end
 end

--- a/spec/factories/session.rb
+++ b/spec/factories/session.rb
@@ -1,0 +1,29 @@
+FactoryBot.define do
+  factory :session do
+    current
+    user
+    token { SecureRandom.uuid }
+
+    raw_info do
+      {
+        "bas:groupId": "flibble",
+        "bas:groupProfile": "https://www.ete.access.service.gov.uk/groupprofile/flibble",
+        "bas:roles": %w[Administrator User],
+        "email": "foo@bar.com",
+        "email_verified": true,
+        "name": "Samwise Gamgee",
+        "profile": "https://www.ete.access.service.gov.uk/profile/samwise",
+        "sub": "1234567890",
+        "exp": 1_748_956_674,
+      }
+    end
+
+    trait :current do
+      expires_at { Time.zone.now + 1.hour }
+    end
+
+    trait :expired do
+      expires_at { Time.zone.now - 1.hour }
+    end
+  end
+end

--- a/spec/helpers/authenticated_sessions_helper_spec.rb
+++ b/spec/helpers/authenticated_sessions_helper_spec.rb
@@ -1,0 +1,45 @@
+RSpec.describe AuthenticatedSessionsHelper, type: :helper do
+  describe "#manage_team_url" do
+    subject(:url) { helper.manage_team_url }
+
+    let(:user_session) { build(:session, raw_info: { "bas:groupProfile" => manage_team_url }) }
+
+    before do
+      allow(helper).to receive(:user_session).and_return(user_session)
+    end
+
+    context "when manage_team_url is present" do
+      let(:manage_team_url) { "https://example.com/my/group/profile" }
+
+      it { is_expected.to eq("https://example.com/my/group/profile?redirect_uri=#{group_redirect_url}") }
+    end
+
+    context "when manage_team_url is blank" do
+      let(:manage_team_url) { "" }
+
+      it { is_expected.to be_nil }
+    end
+  end
+
+  describe "#update_profile_url" do
+    subject(:url) { helper.update_profile_url }
+
+    let(:user_session) { build(:session, raw_info: { "profile" => update_profile_url }) }
+
+    before do
+      allow(helper).to receive(:user_session).and_return(user_session)
+    end
+
+    context "when update_profile_url is present" do
+      let(:update_profile_url) { "https://example.com/my/profile/update" }
+
+      it { is_expected.to eq("https://example.com/my/profile/update?redirect_uri=#{profile_redirect_url}") }
+    end
+
+    context "when update_profile_url is blank" do
+      let(:update_profile_url) { "" }
+
+      it { is_expected.to be_nil }
+    end
+  end
+end

--- a/spec/models/session_spec.rb
+++ b/spec/models/session_spec.rb
@@ -1,0 +1,61 @@
+RSpec.describe Session, type: :model do
+  describe "validations" do
+    subject(:session) { build(:session) }
+
+    it { is_expected.to validate_presence_of(:token) }
+    it { is_expected.to validate_presence_of(:expires_at) }
+    it { is_expected.to validate_uniqueness_of(:token) }
+  end
+
+  describe "#raw_info" do
+    subject(:session) { build(:session) }
+
+    it { expect(session.raw_info).to be_a(Hashie::Mash) }
+  end
+
+  describe "#update_profile_url" do
+    subject(:update_profile_url) { build(:session, raw_info: { profile: "https://example.com/profile" }).update_profile_url }
+
+    it { is_expected.to eq("https://example.com/profile") }
+  end
+
+  describe "#manage_team_url" do
+    subject(:manage_team_url) { build(:session, raw_info: { "bas:groupProfile" => "https://example.com/team" }).manage_team_url }
+
+    it { is_expected.to eq("https://example.com/team") }
+  end
+
+  describe "#email_address" do
+    subject(:email_address) { build(:session, raw_info: { email: "bas@qux.com" }).email_address }
+
+    it { is_expected.to eq("bas@qux.com") }
+  end
+
+  describe "#organisation_account?" do
+    context "when manage_team_url is present" do
+      subject(:session) { build(:session, raw_info: { "bas:groupProfile" => "https://example.com/team" }) }
+
+      it { is_expected.to be_organisation_account }
+    end
+
+    context "when manage_team_url is not present" do
+      subject(:session) { build(:session, raw_info: {}) }
+
+      it { is_expected.not_to be_organisation_account }
+    end
+  end
+
+  describe "#expired?" do
+    context "when the expires_at is before now" do
+      subject(:session) { build(:session, expires_at: 1.hour.ago) }
+
+      it { is_expected.to be_expired }
+    end
+
+    context "when the expires_at is after now" do
+      subject(:session) { build(:session, expires_at: 1.hour.from_now) }
+
+      it { is_expected.not_to be_expired }
+    end
+  end
+end

--- a/spec/requests/user_verification/steps_spec.rb
+++ b/spec/requests/user_verification/steps_spec.rb
@@ -49,6 +49,7 @@ RSpec.describe "Steps", type: :request do
       get user_verification_step_path("details")
       expect(response.body).to include("Register for the FPO Commodity Code Identification Tool")
       expect(response).to render_template("user_verification/steps/_details")
+      expect(response.body).to include(user_session.email_address)
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,9 +3,5 @@ RSpec.configure do |config|
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true
   end
 
-  config.mock_with :rspec do |mocks|
-    mocks.verify_partial_doubles = true
-  end
-
   config.shared_context_metadata_behavior = :apply_to_host_groups
 end

--- a/spec/support/shared_contexts/with_authenticated_user.rb
+++ b/spec/support/shared_contexts/with_authenticated_user.rb
@@ -1,19 +1,21 @@
 RSpec.shared_context "with authenticated user" do
-  let(:status) { :authorised }
   let(:current_user) { create(:user, organisation:) }
-  let(:organisation) { create(:organisation, status:) }
-
-  let(:request_session) do
-    {
-      user_id: current_user.id,
-      organisation_id: organisation.id,
-      user_profile: {
+  let(:organisation) { create(:organisation) }
+  let(:user_session) do
+    create(
+      :session,
+      user: current_user,
+      raw_info: {
         "bas:groupProfile" => "https://example.com/manage-team",
         "profile" => "https://example.com/update-profile",
         "exp" => (Time.zone.now + 1.hour).to_i,
         "email" => current_user.email_address,
       },
-    }.merge(extra_session)
+    )
+  end
+
+  let(:request_session) do
+    { token: user_session.token }.merge(extra_session)
   end
 
   let(:extra_session) { {} }
@@ -29,13 +31,7 @@ RSpec.shared_context "with authenticated user" do
       cookies_key_value = env["action_dispatch.cookies"].as_json.first
       cookies[cookies_key_value.first] = cookies_key_value.last
     else
-      session[:user_id] = current_user.id
-      session[:organisation_id] = organisation.id
-      session[:user_profile] = {
-        "bas:groupProfile" => "https://example.com/manage-team",
-        "profile" => "https://example.com/update-profile",
-        "exp" => (Time.zone.now + 1.hour).to_i,
-      }
+      session[:token] = user_session.token
     end
   end
 end


### PR DESCRIPTION
# Jira link

[HMRC-1166](https://transformuk.atlassian.net/browse/HMRC-1166)

## What?

I have:

- [x] Added support for server side sessions for logout
- [x] Rather than recreating logout when sessions expire just use the `SessionsController#destroy` action

## Why?

I am doing this because:

- This is a more robust approach to logout
