### PR TITLE
HMRC-1458: Limit prod deploy trigger to main branch only

### DIFF
--- a/.github/workflows/deploy-to-production.yml
+++ b/.github/workflows/deploy-to-production.yml
@@ -7,6 +7,8 @@ on:
       - 'Deploy to staging'
     types:
       - completed
+    branches:
+      - main
 
 permissions:
   contents: read


### PR DESCRIPTION
# Jira link

[HMRC-1458](https://transformuk.atlassian.net/browse/HMRC-1458)

## What?

I have:
- [x] added a condition to the production workflow to only run if staging was triggered to main

## Why?

I am doing this because:

- We want to ensure production is deployed only after successful automated staging runs from the main branch
