### PR TITLE
HMRC-1581: Bump terraform modules from v1.13.1 to v1.18.1

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -19,7 +19,7 @@ Terraform to deploy the service into AWS.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_service"></a> [service](#module\_service) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service | aws/ecs-service-v1.13.1 |
+| <a name="module_service"></a> [service](#module\_service) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service | aws/ecs-service-v1.18.1 |
 
 ## Resources
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -28,7 +28,8 @@ module "service" {
   task_role_policy_arns      = [aws_iam_policy.task.arn]
   enable_ecs_exec            = true
 
-  init_container            = true
+  container_definition_kind = "db-backed"
+
   init_container_entrypoint = [""]
   init_container_command = [
     "/bin/sh",

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,5 +1,5 @@
 module "service" {
-  source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service?ref=aws/ecs-service-v1.13.1"
+  source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service?ref=aws/ecs-service-v1.18.1"
 
   region = var.region
 


### PR DESCRIPTION
# Jira link

[HMRC-1581](https://transformuk.atlassian.net/browse/HMRC-1581)

## What?

I have:

- [x] Bumped Terraform modules from v1.13.1 to v1.18.1
- [x] Replace outdated `init_container` var with `container_definition_kind`

## Why?

I am doing this because:

- A new release of the trade-tariff-platform-terraform-modules (v1.18.1) was created following changes made to the main branch.
