### PR TITLE
HMRC-1685: Prevent session replay/CSRF-style attacks

### DIFF
--- a/app/controllers/authenticated_controller.rb
+++ b/app/controllers/authenticated_controller.rb
@@ -37,7 +37,8 @@ protected
       # Clear session if it exists but authentication check failed
       # (authenticated? handles cookie matching, so if it returned false, session is invalid)
       clear_authentication! if user_session.present?
-      redirect_to TradeTariffDevHub.identity_consumer_url, allow_other_host: true
+      session[:state] = state_parameter
+      redirect_to TradeTariffDevHub.identity_consumer_url, allow_other_host: true, state: session[:state]
     end
   end
 
@@ -125,6 +126,10 @@ protected
       clear_authentication!
       redirect_to root_path, alert: "This service is not yet open to the public. If you have any questions please contact us on hmrc-trade-tariff-support-g@digital.hmrc.gov.uk"
     end
+  end
+
+  def state_parameter
+    SecureRandom.hex(16)
   end
 
   helper_method :current_user, :organisation, :user_session

--- a/app/controllers/authenticated_controller.rb
+++ b/app/controllers/authenticated_controller.rb
@@ -37,7 +37,8 @@ protected
       # Clear session if it exists but authentication check failed
       # (authenticated? handles cookie matching, so if it returned false, session is invalid)
       clear_authentication! if user_session.present?
-      redirect_to TradeTariffDevHub.stateful_identity_consumer_url(session), allow_other_host: true
+      session[:state] = TradeTariffDevHub.generate_auth_state!
+      redirect_to TradeTariffDevHub.stateful_identity_consumer_url(session[:state]), allow_other_host: true
     end
   end
 

--- a/app/controllers/authenticated_controller.rb
+++ b/app/controllers/authenticated_controller.rb
@@ -37,8 +37,7 @@ protected
       # Clear session if it exists but authentication check failed
       # (authenticated? handles cookie matching, so if it returned false, session is invalid)
       clear_authentication! if user_session.present?
-      session[:state] = state_parameter
-      redirect_to "#{TradeTariffDevHub.identity_consumer_url}?state=#{state_parameter}", allow_other_host: true
+      redirect_to TradeTariffDevHub.stateful_identity_consumer_url(session), allow_other_host: true
     end
   end
 
@@ -103,10 +102,6 @@ protected
     allowed_roles.none? || allowed_roles.any? { |role| organisation&.has_role?(role) }
   end
 
-  def refresh_session!
-    redirect_to TradeTariffDevHub.identity_consumer_url, allow_other_host: true if user.nil?
-  end
-
   def disallowed_redirect!
     redirect_to root_path, alert: "Your user <strong>#{current_user&.email_address}</strong> does not have the required permissions to access this section"
   end
@@ -126,10 +121,6 @@ protected
       clear_authentication!
       redirect_to root_path, alert: "This service is not yet open to the public. If you have any questions please contact us on hmrc-trade-tariff-support-g@digital.hmrc.gov.uk"
     end
-  end
-
-  def state_parameter
-    @state_parameter ||= SecureRandom.hex(16)
   end
 
   helper_method :current_user, :organisation, :user_session

--- a/app/controllers/authenticated_controller.rb
+++ b/app/controllers/authenticated_controller.rb
@@ -38,7 +38,7 @@ protected
       # (authenticated? handles cookie matching, so if it returned false, session is invalid)
       clear_authentication! if user_session.present?
       session[:state] = state_parameter
-      redirect_to TradeTariffDevHub.identity_consumer_url, allow_other_host: true, state: session[:state]
+      redirect_to "#{TradeTariffDevHub.identity_consumer_url}?state=#{state_parameter}", allow_other_host: true
     end
   end
 
@@ -129,7 +129,7 @@ protected
   end
 
   def state_parameter
-    SecureRandom.hex(16)
+    @state_parameter ||= SecureRandom.hex(16)
   end
 
   helper_method :current_user, :organisation, :user_session

--- a/app/lib/trade_tariff_dev_hub.rb
+++ b/app/lib/trade_tariff_dev_hub.rb
@@ -52,11 +52,9 @@ module TradeTariffDevHub
       ENV.fetch("GOVUK_APP_DOMAIN", "*").sub(/https?:\/\//, "")
     end
 
-    def stateful_identity_consumer_url(session)
-      state = generate_auth_state!
-      session[:state] = state
+    def stateful_identity_consumer_url(state)
       uri = URI.parse(TradeTariffDevHub.identity_consumer_url)
-      uri.query = URI.encode_www_form(["state", state])
+      uri.query = URI.encode_www_form({ "state" => state })
       uri.to_s
     end
 

--- a/app/lib/trade_tariff_dev_hub.rb
+++ b/app/lib/trade_tariff_dev_hub.rb
@@ -52,6 +52,18 @@ module TradeTariffDevHub
       ENV.fetch("GOVUK_APP_DOMAIN", "*").sub(/https?:\/\//, "")
     end
 
+    def stateful_identity_consumer_url(session)
+      state = generate_auth_state!
+      session[:state] = state
+      uri = URI.parse(TradeTariffDevHub.identity_consumer_url)
+      uri.query = URI.encode_www_form(["state", state])
+      uri.to_s
+    end
+
+    def generate_auth_state!
+      SecureRandom.hex(16)
+    end
+
     def identity_consumer_url
       @identity_consumer_url ||= URI.join(identity_base_url, identity_consumer).to_s
     end


### PR DESCRIPTION
# Jira link

[HMRC-1685](https://transformuk.atlassian.net/browse/HMRC-1685)

## What?

I have:

- Added `state` parameter when redirecting to Identity service.
- Added checks for matching `state` when Identity redirects back.
- Added and updated test cases for Session spec.

## Why?

I am doing this because:

- We should protect against creating sessions if the request did not come from this service; by sending the state parameter on a round trip we ensure that only we can create sessions.


> [!NOTE] 
> This is dependant on changes to the Identity service to return the state parameter back to this service. Without those changes, the authentication flow will be broken.