### PR TITLE
OTTIMP-319: Make notes compulsory and show FPO content conditionally

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -15,4 +15,24 @@ document.addEventListener('DOMContentLoaded', () => {
       })
       .catch(err => console.error('Failed to copy:', err))
   })
+
+  // Show/hide FPO-specific content based on role selection
+  const roleSelect = document.getElementById('role_request_role_name')
+  const fpoHintContent = document.getElementById('fpo-hint-content')
+
+  if (roleSelect && fpoHintContent) {
+    const toggleFpoContent = () => {
+      if (roleSelect.value === 'fpo:full') {
+        fpoHintContent.style.display = 'inline'
+      } else {
+        fpoHintContent.style.display = 'none'
+      }
+    }
+
+    // Set initial state
+    toggleFpoContent()
+
+    // Listen for changes
+    roleSelect.addEventListener('change', toggleFpoContent)
+  }
 })

--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -42,7 +42,7 @@ class Invitation < ApplicationRecord
 
     # Restrict admin domain emails to admin organisations only
     if invitee_email&.end_with?("@#{TradeTariffDevHub.admin_domain}") && !organisation.admin?
-      errors.add(:invitee_email, :admin_only)
+      errors.add(:invitee_email, :admin_only, domain: TradeTariffDevHub.admin_domain)
     end
 
     if new_record? && active_invitation.present?

--- a/app/models/role_request.rb
+++ b/app/models/role_request.rb
@@ -30,6 +30,7 @@ class RoleRequest < ApplicationRecord
 
   validates :role_name, presence: true
   validates :role_name, inclusion: { in: Role.assignable_names, message: "is not a valid assignable role" }
+  validates :note, presence: { message: "You must provide information about why you need access to this role" }
   validate :organisation_does_not_have_role
   validate :no_duplicate_pending_request
 

--- a/app/models/role_request.rb
+++ b/app/models/role_request.rb
@@ -31,6 +31,7 @@ class RoleRequest < ApplicationRecord
   validates :role_name, presence: true
   validates :role_name, inclusion: { in: Role.assignable_names, message: "is not a valid assignable role" }
   validates :note, presence: { message: "You must provide information about why you need access to this role" }
+  validates :note, length: { maximum: 200, message: "must be 200 characters or fewer" }
   validate :organisation_does_not_have_role
   validate :no_duplicate_pending_request
 

--- a/app/views/admin/role_requests/index.html.erb
+++ b/app/views/admin/role_requests/index.html.erb
@@ -11,6 +11,7 @@
               row.with_cell(text: 'Requester')
               row.with_cell(text: 'Role requested')
               row.with_cell(text: 'Date requested')
+              row.with_cell(text: 'Notes')
               row.with_cell(text: 'Action')
             end
           end
@@ -22,6 +23,7 @@
                 row.with_cell(text: role_request.user.email_address)
                 row.with_cell(text: role_request.role_name)
                 row.with_cell(text: role_request.created_at.strftime('%d %b %Y'))
+                row.with_cell(text: role_request.note || '')
                 row.with_cell do
                   button_to 'Approve', approve_admin_role_request_path(role_request),
                             method: :post,

--- a/app/views/api_keys/index.html.erb
+++ b/app/views/api_keys/index.html.erb
@@ -39,6 +39,4 @@ end %>
 <%= govuk_button_link_to('Create new key', new_api_key_path, secondary: true) %>
 
 <h2 class="govuk-heading-m">If you need help</h2>
-<p class="govuk-body">If you have any further queries relating to the developer portal contact:
-  <%= mail_to 'hmrc-trade-tariff-support-g@digital.hmrc.gov.uk', 'hmrc-trade-tariff-support-g@digital.hmrc.gov.uk', class: 'govuk-link' %>.
-</p>
+<p class="govuk-body">If you have any further queries relating to the developer portal, <%= govuk_link_to 'use the enquiry form', 'https://www.trade-tariff.service.gov.uk/enquiry_form', target: '_blank' %>.</p>

--- a/app/views/organisations/show.html.erb
+++ b/app/views/organisations/show.html.erb
@@ -114,3 +114,6 @@
 <% end %>
 
 <%= govuk_button_link_to 'Invite new member', new_invitation_path %>
+
+<h2 class="govuk-heading-m">If you need help</h2>
+<p class="govuk-body">If you have any further queries relating to the developer portal, <%= govuk_link_to 'use the enquiry form', 'https://www.trade-tariff.service.gov.uk/enquiry_form', target: '_blank' %>.</p>

--- a/app/views/role_requests/new.html.erb
+++ b/app/views/role_requests/new.html.erb
@@ -3,16 +3,24 @@
 
   <p class="govuk-body">Select a role you would like to request access to for your organisation. This request will be reviewed by HMRC and you will be notified.</p>
 
+  <% if @available_roles.map(&:name).include?("fpo:full") %>
+    <div class="govuk-inset-text govuk-!-margin-bottom-4">
+      <p class="govuk-body">
+        <strong>FPO (Fast Parcel Operator) API access:</strong> The FPO (Fast Parcel Operator) Commodity Code Identification Tool API is a free-to-use API available to UK Carrier Scheme (UKC)–registered organisations. To enable access, HMRC requires additional information to verify eligibility and organisational use, including company identification details.
+      </p>
+    </div>
+  <% end %>
+
   <div class="govuk-form-group">
     <%= f.govuk_label :role_name, text: "Role" %>
     <div class="govuk-hint">Your request will be reviewed by administrators</div>
     <% role_options = @available_roles.map { |role| ["#{role.name} – #{role.description}", role.name] } %>
-    <%= f.select :role_name, role_options, {}, { class: "govuk-select govuk-!-width-two-thirds" } %>
+    <%= f.select :role_name, role_options, {}, { class: "govuk-select govuk-!-width-two-thirds", id: "role_request_role_name", data: { action: "role-selection-change" } } %>
   </div>
 
   <%= f.govuk_text_area :note,
-                        label: { text: "Note (optional)" },
-                        hint: { text: "Provide any additional information about why you need this access" },
+                        label: { text: "Note" },
+                        hint: { text: raw("Provide information about why you need this access.#{@available_roles.map(&:name).include?('fpo:full') ? "<span id='fpo-hint-content' style='display: none;'><br><br><strong>The FPO (Fast Parcel Operator) Commodity Code Identification Tool API</strong> is a free-to-use API available to UK <strong>Carrier Scheme (UKC)</strong>–registered organisations. To enable access, HMRC requires additional information to verify eligibility and organisational use, including company identification details.</span>" : ''}") },
                         rows: 5,
                         width: 'two-thirds' %>
 

--- a/app/views/trade_tariff_keys/index.html.erb
+++ b/app/views/trade_tariff_keys/index.html.erb
@@ -38,6 +38,4 @@ end %>
 <%= govuk_button_link_to('Create new Trade Tariff key', new_trade_tariff_key_path, secondary: true) %>
 
 <h2 class="govuk-heading-m">If you need help</h2>
-<p class="govuk-body">If you have any further queries relating to the developer portal contact:
-  <%= mail_to 'hmrc-trade-tariff-support-g@digital.hmrc.gov.uk', 'hmrc-trade-tariff-support-g@digital.hmrc.gov.uk', class: 'govuk-link' %>.
-</p>
+<p class="govuk-body">If you have any further queries relating to the developer portal, <%= govuk_link_to 'use the enquiry form', 'https://www.trade-tariff.service.gov.uk/enquiry_form', target: '_blank' %>.</p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -10,7 +10,7 @@ en:
               taken: This email address has already been invited to an organisation
               already_member: This email address is already associated with a member of your organisation
               member_elsewhere: This email address is already associated with a member of another organisation
-              admin_only: "<%= ENV.fetch('ADMIN_DOMAIN', 'transformuk.com') %> email addresses can only be invited to admin organisations"
+              admin_only: "%{domain} email addresses can only be invited to admin organisations"
         organisation:
           attributes:
             organisation_name:

--- a/spec/models/invitation_spec.rb
+++ b/spec/models/invitation_spec.rb
@@ -70,6 +70,29 @@ RSpec.describe Invitation, type: :model do
         expect(invitation.errors[:invitee_email]).to include("This email address is already associated with a member of your organisation")
       end
     end
+
+    context "when inviting admin domain email to non-admin organisation" do
+      let(:non_admin_org) { create(:organisation) }
+      let(:admin_domain) { TradeTariffDevHub.admin_domain }
+
+      it "adds an error with the correct domain name", :aggregate_failures do
+        invitation.invitee_email = "user@#{admin_domain}"
+        invitation.organisation = non_admin_org
+        expect(invitation).not_to be_valid
+        expect(invitation.errors[:invitee_email]).to include("#{admin_domain} email addresses can only be invited to admin organisations")
+      end
+    end
+
+    context "when inviting admin domain email to admin organisation" do
+      let(:admin_org) { create(:organisation, :admin) }
+      let(:admin_domain) { TradeTariffDevHub.admin_domain }
+
+      it "allows the invitation", :aggregate_failures do
+        invitation.invitee_email = "user@#{admin_domain}"
+        invitation.organisation = admin_org
+        expect(invitation).to be_valid
+      end
+    end
   end
 
   describe "#send_email" do

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -53,14 +53,6 @@ RSpec.describe Notification do
       expect(notification.personalisation).to eq(expected_personalisation)
     end
 
-    context "when note is blank" do
-      let(:role_request) { create(:role_request, organisation: organisation, user: user, role_name: "fpo:full", note: nil) }
-
-      it "uses default note text" do
-        expect(notification.personalisation[:note]).to eq("No note provided")
-      end
-    end
-
     context "when role description is missing" do
       let(:role_request) { create(:role_request, organisation: organisation, user: user, role_name: "fpo:full", note: "Test") }
 

--- a/spec/models/role_request_spec.rb
+++ b/spec/models/role_request_spec.rb
@@ -57,6 +57,33 @@ RSpec.describe RoleRequest, type: :model do
     end
   end
 
+  describe "validations" do
+    let(:organisation) { create(:organisation) }
+    let(:user) { create(:user, organisation: organisation) }
+
+    describe "#note" do
+      it "requires a note to be present", :aggregate_failures do
+        role_request = build(:role_request, organisation: organisation, user: user, note: nil)
+
+        expect(role_request).not_to be_valid
+        expect(role_request.errors[:note]).to include("You must provide information about why you need access to this role")
+      end
+
+      it "requires a note to not be blank", :aggregate_failures do
+        role_request = build(:role_request, organisation: organisation, user: user, note: "")
+
+        expect(role_request).not_to be_valid
+        expect(role_request.errors[:note]).to include("You must provide information about why you need access to this role")
+      end
+
+      it "allows a role request with a note" do
+        role_request = build(:role_request, organisation: organisation, user: user, note: "I need this access")
+
+        expect(role_request).to be_valid
+      end
+    end
+  end
+
   describe "#organisation_does_not_have_role" do
     let(:organisation) { create(:organisation) }
     let(:user) { create(:user, organisation: organisation) }

--- a/spec/models/role_request_spec.rb
+++ b/spec/models/role_request_spec.rb
@@ -177,4 +177,37 @@ RSpec.describe RoleRequest, type: :model do
       end
     end
   end
+
+  describe "note validation" do
+    let(:organisation) { create(:organisation) }
+    let(:user) { create(:user, organisation: organisation) }
+
+    context "when note exceeds 200 characters" do
+      it "prevents creating a role request with note that is too long", :aggregate_failures do
+        long_note = "a" * 201
+        role_request = build(:role_request, organisation: organisation, user: user, note: long_note)
+
+        expect(role_request).not_to be_valid
+        expect(role_request.errors[:note]).to include("must be 200 characters or fewer")
+      end
+    end
+
+    context "when note is exactly 200 characters" do
+      it "allows creating a role request" do
+        note = "a" * 200
+        role_request = build(:role_request, organisation: organisation, user: user, note: note)
+
+        expect(role_request).to be_valid
+      end
+    end
+
+    context "when note is less than 200 characters" do
+      it "allows creating a role request" do
+        note = "a" * 199
+        role_request = build(:role_request, organisation: organisation, user: user, note: note)
+
+        expect(role_request).to be_valid
+      end
+    end
+  end
 end

--- a/spec/requests/invitations_spec.rb
+++ b/spec/requests/invitations_spec.rb
@@ -78,6 +78,23 @@ RSpec.describe "Invitations", type: :request do
         expect(response.body).to include("Enter a properly formatted email address")
       end
     end
+
+    context "when inviting admin domain email to non-admin organisation" do
+      let(:admin_domain) { TradeTariffDevHub.admin_domain }
+      let(:params) { { invitation: { invitee_email: "user@#{admin_domain}" } } }
+
+      it "does not create a new invitation", :aggregate_failures do
+        expect { post invitations_path, params: params }
+          .not_to change(Invitation, :count)
+      end
+
+      it "re-renders the new template with admin domain error", :aggregate_failures do
+        post invitations_path, params: params
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("#{admin_domain} email addresses can only be invited to admin organisations")
+        expect(response.body).not_to include("<%= ENV.fetch")
+      end
+    end
   end
 
   describe "GET /invitations/:id/revoke" do

--- a/spec/requests/role_requests_spec.rb
+++ b/spec/requests/role_requests_spec.rb
@@ -10,6 +10,33 @@ RSpec.describe "Role Requests", type: :request do
       get new_role_request_path
       expect(response).to have_http_status(:ok)
       expect(response.body).to include("Request access")
+      expect(response.body).to include("Note")
+      expect(response.body).not_to include("Note (optional)")
+    end
+
+    context "when FPO role is available" do
+      it "displays FPO-specific information in inset box and includes FPO hint content (hidden by default)", :aggregate_failures do
+        get new_role_request_path
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("FPO (Fast Parcel Operator) API access")
+        expect(response.body).to include("UK Carrier Scheme (UKC)–registered organisations")
+        # FPO hint content is in the HTML but hidden by default, shown only when FPO is selected
+        expect(response.body).to include("fpo-hint-content")
+        expect(response.body).to include("The FPO (Fast Parcel Operator) Commodity Code Identification Tool API is a free-to-use API")
+      end
+    end
+
+    context "when FPO role is not available" do
+      before do
+        current_user.organisation.assign_role!("fpo:full")
+      end
+
+      it "does not display FPO-specific information in inset box or hint", :aggregate_failures do
+        get new_role_request_path
+        expect(response).to have_http_status(:ok)
+        expect(response.body).not_to include("FPO (Fast Parcel Operator) API access")
+        expect(response.body).not_to include("fpo-hint-content")
+      end
     end
 
     context "when user is an admin" do
@@ -82,25 +109,72 @@ RSpec.describe "Role Requests", type: :request do
     end
 
     context "with invalid parameters" do
-      let(:params) do
-        {
-          role_request: {
-            role_name: "invalid:role",
-            note: "",
-          },
-        }
+      # rubocop:disable RSpec/NestedGroups
+      context "when role_name is invalid" do
+        let(:params) do
+          {
+            role_request: {
+              role_name: "invalid:role",
+              note: "Some note",
+            },
+          }
+        end
+
+        it "does not create a role request" do
+          expect { post role_requests_path, params: params }
+            .not_to change(RoleRequest, :count)
+        end
+
+        it "re-renders the new template with errors", :aggregate_failures do
+          post role_requests_path, params: params
+          expect(response).to have_http_status(:ok)
+          expect(response.body).to include("is not a valid assignable role")
+        end
       end
 
-      it "does not create a role request" do
-        expect { post role_requests_path, params: params }
-          .not_to change(RoleRequest, :count)
+      context "when note is blank" do
+        let(:params) do
+          {
+            role_request: {
+              role_name: "fpo:full",
+              note: "",
+            },
+          }
+        end
+
+        it "does not create a role request" do
+          expect { post role_requests_path, params: params }
+            .not_to change(RoleRequest, :count)
+        end
+
+        it "re-renders the new template with errors", :aggregate_failures do
+          post role_requests_path, params: params
+          expect(response).to have_http_status(:ok)
+          expect(response.body).to include("You must provide information about why you need access to this role")
+        end
       end
 
-      it "re-renders the new template with errors", :aggregate_failures do
-        post role_requests_path, params: params
-        expect(response).to have_http_status(:ok)
-        expect(response.body).to include("is not a valid assignable role")
+      context "when note is missing" do
+        let(:params) do
+          {
+            role_request: {
+              role_name: "fpo:full",
+            },
+          }
+        end
+
+        it "does not create a role request" do
+          expect { post role_requests_path, params: params }
+            .not_to change(RoleRequest, :count)
+        end
+
+        it "re-renders the new template with errors", :aggregate_failures do
+          post role_requests_path, params: params
+          expect(response).to have_http_status(:ok)
+          expect(response.body).to include("You must provide information about why you need access to this role")
+        end
       end
+      # rubocop:enable RSpec/NestedGroups
     end
 
     context "when duplicate pending request exists" do

--- a/spec/requests/role_requests_spec.rb
+++ b/spec/requests/role_requests_spec.rb
@@ -190,5 +190,24 @@ RSpec.describe "Role Requests", type: :request do
         expect(response.body).to include("has already been requested and is pending")
       end
     end
+
+    context "when note exceeds 200 characters" do
+      let(:params) do
+        {
+          role_request: {
+            role_name: "fpo:full",
+            note: "a" * 201,
+          },
+        }
+      end
+
+      it "does not create a role request", :aggregate_failures do
+        expect { post role_requests_path, params: params }
+          .not_to change(RoleRequest, :count)
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("must be 200 characters or fewer")
+      end
+    end
   end
 end


### PR DESCRIPTION
# Jira link

[OTTIMP-319](https://transformuk.atlassian.net/browse/OTTIMP-319)

## What?

I have:

- [x] Added validation to make notes field compulsory for role requests
- [x] Added JavaScript to show/hide FPO-specific content based on role dropdown selection
- [x] Added FPO-specific informational text that appears only when FPO role is selected
- [x] Added comprehensive test coverage for note validation and conditional FPO content

## Why?

I am doing this because:

- It's important to collect information on why developers need access to roles
- FPO-specific information should only be shown when relevant (when FPO is selected)
- Users should see contextual help text only when it applies to their selection