### PR TITLE
OTTIMP-330: Remove `spimm:full` from role request options

### DIFF
--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -105,8 +105,10 @@ class Organisation < ApplicationRecord
   end
 
   def available_service_roles
-    assigned_service_role_ids = roles.service_roles.pluck(:id)
-    Role.service_roles.where.not(id: assigned_service_role_ids).order(:name)
+    # Only return roles that can be requested through the dev-portal request form.
+    assignable = Role.requestable_service_roles
+    assigned_assignable_ids = roles.merge(assignable).pluck(:id)
+    assignable.where.not(id: assigned_assignable_ids).order(:name)
   end
 
   def pending_request_for?(role_name)

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -16,6 +16,9 @@
 class Role < ApplicationRecord
   ADMIN_ROLE_NAME = "admin".freeze
   SERVICE_ROLE_NAMES = %w[trade_tariff:full fpo:full spimm:full].freeze
+  # Roles that can be requested via the developer portal "Request access" flow.
+  # (Some service roles are admin-managed only, and should not appear in the request dropdown.)
+  REQUESTABLE_SERVICE_ROLE_NAMES = %w[trade_tariff:full fpo:full].freeze
 
   validates :name, presence: true, uniqueness: true
   validates :description, presence: true
@@ -24,9 +27,10 @@ class Role < ApplicationRecord
   has_paper_trail
 
   scope :service_roles, -> { where(name: SERVICE_ROLE_NAMES) }
+  scope :requestable_service_roles, -> { where(name: REQUESTABLE_SERVICE_ROLE_NAMES) }
 
   def self.assignable_names
-    SERVICE_ROLE_NAMES
+    REQUESTABLE_SERVICE_ROLE_NAMES
   end
 
   def admin?

--- a/app/models/role_request.rb
+++ b/app/models/role_request.rb
@@ -29,7 +29,9 @@ class RoleRequest < ApplicationRecord
   attribute :status, :string
 
   validates :role_name, presence: true
-  validates :role_name, inclusion: { in: Role.assignable_names, message: "is not a valid assignable role" }
+  # Only enforce requestable roles on creation. This avoids breaking admin processing
+  # of previously-created requests if the allowed list changes over time.
+  validates :role_name, inclusion: { in: Role.assignable_names, message: "is not a valid assignable role" }, on: :create
   validate :organisation_does_not_have_role
   validate :no_duplicate_pending_request
 

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -143,7 +143,7 @@ RSpec.describe Organisation, type: :model do
 
     context "when organisation has no service roles" do
       it "returns all service roles" do
-        expect(organisation.available_service_roles.pluck(:name)).to contain_exactly("fpo:full", "spimm:full", "trade_tariff:full")
+        expect(organisation.available_service_roles.pluck(:name)).to contain_exactly("fpo:full", "trade_tariff:full")
       end
     end
 
@@ -155,7 +155,7 @@ RSpec.describe Organisation, type: :model do
       end
 
       it "returns only unassigned service roles" do
-        expect(organisation.available_service_roles.pluck(:name)).to contain_exactly("spimm:full", "trade_tariff:full")
+        expect(organisation.available_service_roles.pluck(:name)).to contain_exactly("trade_tariff:full")
       end
     end
 


### PR DESCRIPTION
Limit requestable roles to `trade_tariff:full` and `fpo:full` so `spimm:full` no longer appears in the dev request form dropdown.

# Jira link

[OTTIMP-330](https://transformuk.atlassian.net/browse/OTTIMP-330)

## What?

I have:

- [ ] Added requestable role list (`trade_tariff:full`, `fpo:full`)
- [ ] Removed `spimm:full` from role request dropdown options

## Why?

I am doing this because:

- `spimm:full` should be admin-managed, not user-requestable
- Keeps the request form aligned with supported roles
- Reduces invalid/unwanted access requests