### PR TITLE
OTTIMP-387: Add categorisation and FPO OAuth scopes to dev-hub SCOPE_MAP

### DIFF
--- a/app/services/identity/client_credentials_api.rb
+++ b/app/services/identity/client_credentials_api.rb
@@ -5,7 +5,8 @@ module Identity
     # Maps dev-hub scope names to identity/OAuth scope names.
     SCOPE_MAP = {
       "read" => "tariff/read",
-      "write" => "tariff/write",
+      "categorisation" => "tariff/categorisation",
+      "fpo" => "tariff/fpo"
     }.freeze
 
     CreateResult = Struct.new(:client_id, :client_secret, keyword_init: true)

--- a/docs/rfcs/api-scopes.md
+++ b/docs/rfcs/api-scopes.md
@@ -1,0 +1,26 @@
+# API Scope Mapping (Cognito Resource Server)
+
+## Available Scopes
+
+- `tariff/read` – read access to Tariff API
+- `tariff/categorisation` – access to Categorisation (green_lanes) endpoints
+- `tariff/fpo` – access to Freeports API (future integration)
+- `tariff/write` – admin/internal (legacy)
+
+## Path Mapping
+
+### tariff/read
+- /uk/api/*
+- /xi/api/*
+(excluding categorisation routes)
+
+### tariff/categorisation
+- /uk/api/green_lanes/*
+- /xi/api/green_lanes/*
+
+### tariff/fpo
+- external today, future API Gateway migration
+
+## Notes
+- Dev-hub uses friendly names: read, categorisation, fpo.
+- Identity-service maps these to OAuth scopes via SCOPE_MAP.


### PR DESCRIPTION
# Jira link

[OTTIMP-387(https://transformuk.atlassian.net/browse/OTTIMP-387)

## What?

I have:

- [x] Added new OAuth scopes for Categorisation (formerly SPIMM) and Freeports (FPO) to the  identity-service SCOPE_MAP.
- [x] Added API Scope Mapping doc
## Why?

I am doing this because:

- Epic 383 introduces scoped authentication via Cognito.  
Dev-hub needs to request the correct OAuth scopes when creating new machine‑to‑machine (client_credentials) clients through the identity-service API.
