### PR TITLE
Test cleanup tflock on cancellation

### DIFF
--- a/.github/workflows/deploy-to-development.yml
+++ b/.github/workflows/deploy-to-development.yml
@@ -19,7 +19,7 @@ jobs:
     if: >
       github.event_name == 'workflow_dispatch' ||
       contains(github.event.pull_request.labels.*.name, 'needs-deployment')
-    uses: trade-tariff/trade-tariff-tools/.github/workflows/deploy-ecs.yml@feature/clean-up-tflock-on-cancellation
+    uses: trade-tariff/trade-tariff-tools/.github/workflows/deploy-ecs.yml@main
     with:
       app-name: tariff-dev-hub
       environment: development

--- a/.github/workflows/deploy-to-development.yml
+++ b/.github/workflows/deploy-to-development.yml
@@ -19,7 +19,7 @@ jobs:
     if: >
       github.event_name == 'workflow_dispatch' ||
       contains(github.event.pull_request.labels.*.name, 'needs-deployment')
-    uses: trade-tariff/trade-tariff-tools/.github/workflows/deploy-ecs.yml@main
+    uses: trade-tariff/trade-tariff-tools/.github/workflows/deploy-ecs.yml@feature/clean-up-tflock-on-cancellation
     with:
       app-name: tariff-dev-hub
       environment: development

--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -1,0 +1,2 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.

--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -1,2 +1,0 @@
-# This file is maintained automatically by "terraform init".
-# Manual edits may be lost in future updates.

--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -44,3 +44,23 @@ provider "registry.terraform.io/hashicorp/random" {
     "zh:fa985cd0b11e6d651f47cff3055f0a9fd085ec190b6dbe99bf5448174434cdea",
   ]
 }
+
+provider "registry.terraform.io/hashicorp/time" {
+  version     = "0.13.1"
+  constraints = "~> 0.12"
+  hashes = [
+    "h1:ZT5ppCNIModqk3iOkVt5my8b8yBHmDpl663JtXAIRqM=",
+    "zh:02cb9aab1002f0f2a94a4f85acec8893297dc75915f7404c165983f720a54b74",
+    "zh:04429b2b31a492d19e5ecf999b116d396dac0b24bba0d0fb19ecaefe193fdb8f",
+    "zh:26f8e51bb7c275c404ba6028c1b530312066009194db721a8427a7bc5cdbc83a",
+    "zh:772ff8dbdbef968651ab3ae76d04afd355c32f8a868d03244db3f8496e462690",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:898db5d2b6bd6ca5457dccb52eedbc7c5b1a71e4a4658381bcbb38cedbbda328",
+    "zh:8de913bf09a3fa7bedc29fec18c47c571d0c7a3d0644322c46f3aa648cf30cd8",
+    "zh:9402102c86a87bdfe7e501ffbb9c685c32bbcefcfcf897fd7d53df414c36877b",
+    "zh:b18b9bb1726bb8cfbefc0a29cf3657c82578001f514bcf4c079839b6776c47f0",
+    "zh:b9d31fdc4faecb909d7c5ce41d2479dd0536862a963df434be4b16e8e4edc94d",
+    "zh:c951e9f39cca3446c060bd63933ebb89cedde9523904813973fbc3d11863ba75",
+    "zh:e5b773c0d07e962291be0e9b413c7a22c044b8c7b58c76e8aa91d1659990dfb5",
+  ]
+}

--- a/terraform/backends/development.tfbackend
+++ b/terraform/backends/development.tfbackend
@@ -2,3 +2,4 @@ bucket  = "terraform-state-development-844815912454"
 key     = "dev-hub.tfstate"
 region  = "eu-west-2"
 encrypt = true
+use_lockfile = true

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,3 +1,8 @@
+# TESTING ONLY - remove before merge
+resource "time_sleep" "cancel_test" {
+  create_duration = "3m"
+}
+
 module "service" {
   source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service?ref=aws/ecs-service-v1.21.0"
 

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -6,6 +6,10 @@ terraform {
       source  = "hashicorp/aws"
       version = "~> 5"
     }
+    time = {
+      source  = "hashicorp/time"
+      version = "~> 0.12"
+    }
   }
 
   backend "s3" {}


### PR DESCRIPTION
Do not merge this branch. 

This PR exists to provide a test deploy to test cleaning up terraform lock files on cancellation of a workflow here: https://github.com/trade-tariff/trade-tariff-tools/pull/103

This can be closed without merging once the above PR is merged.