### PR TITLE
Fix admin org page when Trade Tariff key has no stored secret

### DIFF
--- a/app/views/shared/_masked_secret_toggle.html.erb
+++ b/app/views/shared/_masked_secret_toggle.html.erb
@@ -1,6 +1,11 @@
 <% masked_id = "#{prefix}-secret-#{record.id}" %>
 <% full_id = "#{prefix}-secret-full-#{record.id}" %>
+<% secret = record.secret %>
 
-<%= content_tag(:span, "****#{record.secret[-4..]}", id: masked_id, class: "#{prefix}-secret-masked") %>
-<%= content_tag(:span, record.secret, id: full_id, class: "#{prefix}-secret-full", style: 'display: none;') %>
-<%= content_tag(:button, 'Show', type: 'button', class: 'govuk-button govuk-button--secondary govuk-!-margin-left-2', style: 'font-size: 14px; padding: 5px 10px;', onclick: "document.getElementById('#{masked_id}').style.display='none'; document.getElementById('#{full_id}').style.display='inline'; this.style.display='none';") %>
+<% if secret.present? %>
+  <%= content_tag(:span, "****#{secret[-4..]}", id: masked_id, class: "#{prefix}-secret-masked") %>
+  <%= content_tag(:span, secret, id: full_id, class: "#{prefix}-secret-full", style: 'display: none;') %>
+  <%= content_tag(:button, 'Show', type: 'button', class: 'govuk-button govuk-button--secondary govuk-!-margin-left-2', style: 'font-size: 14px; padding: 5px 10px;', onclick: "document.getElementById('#{masked_id}').style.display='none'; document.getElementById('#{full_id}').style.display='inline'; this.style.display='none';") %>
+<% else %>
+  <%= content_tag(:span, "—", class: "#{prefix}-secret-masked") %>
+<% end %>


### PR DESCRIPTION
# Jira link

[OTTIMP-469](https://transformuk.atlassian.net/browse/OTTIMP-469)

Handles nil secret on trade tariff keys (Cognito flow) in masked_secret_toggle so the admin organisation show page no longer 500s; shows “—” when there is nothing to mask.
