### PR TITLE
OTTIMP-499 Refactor admin allowed

### DIFF
--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -1,0 +1,7 @@
+class Admin::BaseController < AuthenticatedController
+private
+
+  def allowed_roles
+    %w[admin]
+  end
+end

--- a/app/controllers/admin/organisation_roles_controller.rb
+++ b/app/controllers/admin/organisation_roles_controller.rb
@@ -1,5 +1,4 @@
-class Admin::OrganisationRolesController < AuthenticatedController
-  before_action :ensure_admin
+class Admin::OrganisationRolesController < Admin::BaseController
   before_action :set_organisation
   before_action :validate_role_name
 
@@ -24,10 +23,6 @@ class Admin::OrganisationRolesController < AuthenticatedController
   end
 
 private
-
-  def ensure_admin
-    redirect_to root_path, alert: "Access denied" unless organisation.admin?
-  end
 
   def set_organisation
     @organisation = Organisation.find(params[:organisation_id])

--- a/app/controllers/admin/organisations_controller.rb
+++ b/app/controllers/admin/organisations_controller.rb
@@ -1,7 +1,5 @@
-class Admin::OrganisationsController < AuthenticatedController
+class Admin::OrganisationsController < Admin::BaseController
   include Pagy::Backend
-
-  before_action :ensure_admin
 
   def index
     @sort_column = params[:sort].presence || "created_at"
@@ -37,21 +35,5 @@ class Admin::OrganisationsController < AuthenticatedController
     @api_keys = @organisation.api_keys
     @trade_tariff_keys = @organisation.trade_tariff_keys
     @invitations = @organisation.invitations.reject(&:accepted?)
-  end
-
-private
-
-  def ensure_admin
-    redirect_to root_path, alert: "Access denied" unless organisation.admin?
-  end
-
-  def allowed?
-    # Override to check for admin role
-    organisation.admin?
-  end
-
-  def allowed_roles
-    # Empty to allow any role, we check admin in allowed?
-    %w[admin]
   end
 end

--- a/app/controllers/admin/role_requests_controller.rb
+++ b/app/controllers/admin/role_requests_controller.rb
@@ -1,10 +1,9 @@
 # frozen_string_literal: true
 
-class Admin::RoleRequestsController < AuthenticatedController
+class Admin::RoleRequestsController < Admin::BaseController
   include Pagy::Backend
 
   before_action :ensure_role_request_enabled
-  before_action :ensure_admin
   before_action :set_role_request, only: %i[approve reject]
 
   def index
@@ -49,16 +48,10 @@ class Admin::RoleRequestsController < AuthenticatedController
     redirect_to admin_role_requests_path, alert: "There was an unexpected problem rejecting the role request. Please try again."
   end
 
-private
-
   def ensure_role_request_enabled
     return if TradeTariffDevHub.role_request_enabled?
 
     redirect_to root_path, alert: "This feature is currently disabled."
-  end
-
-  def ensure_admin
-    redirect_to root_path, alert: "Access denied" unless organisation.admin?
   end
 
   def set_role_request

--- a/app/controllers/trade_tariff_keys_controller.rb
+++ b/app/controllers/trade_tariff_keys_controller.rb
@@ -88,8 +88,4 @@ private
   def trade_tariff_key_params
     params.permit(:trade_tariff_key_description)
   end
-
-  def allowed_roles
-    ["trade_tariff:full"]
-  end
 end

--- a/spec/requests/admin/role_requests_spec.rb
+++ b/spec/requests/admin/role_requests_spec.rb
@@ -200,7 +200,7 @@ RSpec.describe "Admin Role Requests", type: :request do
         get admin_role_requests_path
         expect(response).to redirect_to(root_path)
         follow_redirect!
-        expect(response.body).to include("Access denied")
+        expect(response.body).to include("does not have the required permissions to access this section")
       end
     end
 


### PR DESCRIPTION
# Jira link

[OTTIMP-499](https://transformuk.atlassian.net/browse/OTTIMP-499)

## What?

Adds an admin base class and sets the allowed role for these controllers as `admin`
Removes the `ensure_admin` before action and relies on the AuthenticatedController authorisation

Removes allowed_keys method from TradeTariffKeysController as it is the same as the default in the base class
