### PR TITLE
OTTIMP-501 Remove deprecated description

### DIFF
--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -4,10 +4,10 @@ class ErrorsController < ApplicationController
     render_error(status: :not_found, header: "Page not found", message:, json_error: "Resource not found")
   end
 
-  def unprocessable_entity
+  def unprocessable_content
     message = "We're sorry, but we cannot process your request at this time.<br>
                Please contact support for assistance or try a different request.".html_safe
-    render_error(status: :unprocessable_content, header: "Unprocessable entity", message:)
+    render_error(status: :unprocessable_content, message:)
   end
 
   def internal_server_error
@@ -46,7 +46,7 @@ class ErrorsController < ApplicationController
 
   def too_many_requests
     message = "You have made too many requests. Please try again later."
-    render_error(status: :too_many_requests, header: "Too many requests", message:)
+    render_error(status: :too_many_requests, message:)
   end
 
 private

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -87,7 +87,7 @@ Rails.application.routes.draw do
   match "/404", to: "errors#not_found", via: :all, as: :not_found
   match "/405", to: "errors#method_not_allowed", via: :all
   match "/406", to: "errors#not_acceptable", via: :all
-  match "/422", to: "errors#unprocessable_entity", via: :all
+  match "/422", to: "errors#unprocessable_content", via: :all
   match "/429", to: "errors#too_many_requests", via: :all
   match "/500", to: "errors#internal_server_error", via: :all
   match "/501", to: "errors#not_implemented", via: :all


### PR DESCRIPTION
# Jira link

[OTTIMP-501](https://transformuk.atlassian.net/browse/OTTIMP-501)

## What?

Rack has deprecated `unprocessable_entity` as a symbol for HTTP status code 422. This is not being used, but for consistency the related method has been updated to match the correct `unprocessable_content` symbol.
