### PR TITLE
Auto-assign trade_tariff:full to new self-service orgs and gate prod signups purely via feature flag

### DIFF
--- a/app/controllers/authenticated_controller.rb
+++ b/app/controllers/authenticated_controller.rb
@@ -114,20 +114,19 @@ protected
     redirect_to root_path, alert: "Your user <strong>#{current_user&.email_address}</strong> does not have the required permissions to access this section"
   end
 
-  # Any organisation that DOES NOT have the fpo:full or admin roles needs to be redirected to the start with a flash
+  # Any organisation that DOES NOT have the fpo:full, trade_tariff:full, or admin roles needs to be redirected to the start with a flash
   # Any expired session needs to be redirected to the identity service to refresh the token
-  # Any non-expired session with the fpo:full role can continue
+  # Any non-expired session with one of the allowed roles can continue
   def handle_user_session
     unless TradeTariffDevHub.block_non_fpo_identity_sessions_in_production?
       renew_identity_session_if_needed
       return
     end
 
-    if organisation&.fpo? || organisation&.admin?
+    if organisation&.fpo? || organisation&.admin? || organisation&.trade_tariff_access?
       renew_identity_session_if_needed
     else
-      # NOTE:  Non-FPO orgs should not have an identity session - destroy it
-      Rails.logger.info("[Auth] Non-FPO org detected, clearing authentication")
+      Rails.logger.info("[Auth] Non-permitted org detected, clearing authentication")
       clear_authentication!
       redirect_to root_path, alert: "This service is not yet open to the public. If you have any questions please contact us on hmrc-trade-tariff-support-g@digital.hmrc.gov.uk"
     end

--- a/app/lib/trade_tariff_dev_hub.rb
+++ b/app/lib/trade_tariff_dev_hub.rb
@@ -34,11 +34,11 @@ module TradeTariffDevHub
       false
     end
 
-    # Allowed when self-service is enabled and this is not the live production slot.
+    # Allowed purely based on the self-service org creation feature flag.
+    # Production remains gated because self_service_org_creation_enabled? defaults to false there
+    # unless FEATURE_FLAG_SELF_SERVICE_ORG_CREATION=true is set explicitly.
     def allow_passwordless_self_service_org_creation?
-      return false unless self_service_org_creation_enabled?
-
-      environment != "production"
+      self_service_org_creation_enabled?
     end
 
     def documentation_url

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -15,7 +15,9 @@
 
 class Role < ApplicationRecord
   ADMIN_ROLE_NAME = "admin".freeze
-  SERVICE_ROLE_NAMES = %w[trade_tariff:full fpo:full].freeze
+  TRADE_TARIFF_ROLE_NAME = "trade_tariff:full".freeze
+  FPO_ROLE_NAME = "fpo:full".freeze
+  SERVICE_ROLE_NAMES = [TRADE_TARIFF_ROLE_NAME, FPO_ROLE_NAME].freeze
 
   validates :name, presence: true, uniqueness: true
   validates :description, presence: true

--- a/app/services/associate_user_to_organisation.rb
+++ b/app/services/associate_user_to_organisation.rb
@@ -35,10 +35,12 @@ private
 
   def create_and_associate_self_service_organisation(user)
     User.transaction do
-      user.organisation = Organisation.create!(
+      organisation = Organisation.create!(
         organisation_name: user.email_address,
         description: "Self-service organisation for #{user.email_address}",
       )
+      organisation.assign_role!(Role::TRADE_TARIFF_ROLE_NAME)
+      user.organisation = organisation
       user.save!
     end
   end

--- a/spec/controllers/authenticated_controller_spec.rb
+++ b/spec/controllers/authenticated_controller_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe AuthenticatedController, type: :controller do
       get "test_action" => "organisations#test_action"
       get "/dev/login", to: "dev_auth#new", as: :dev_login
       get "/organisations/:id", to: "organisations#show", as: :organisation
+      root to: "homepage#index"
     end
   end
 
@@ -115,6 +116,45 @@ RSpec.describe AuthenticatedController, type: :controller do
         it "allows access" do
           get :test_action
           expect(response).to have_http_status(:ok)
+        end
+      end
+
+      context "when the user's org only has the trade_tariff:full role" do
+        let(:valid_verify_result) { VerifyToken::Result.new(valid: true, payload: {}, reason: nil) }
+        let(:current_user) { create(:user, organisation: create(:organisation, :trade_tariff_only)) }
+
+        before do
+          create(:session, user: current_user, token: plain_token, id_token: id_token_value)
+          session[:token] = plain_token
+          cookies[TradeTariffDevHub.id_token_cookie_name] = id_token_value
+          allow(VerifyToken).to receive(:new).with(id_token_value).and_return(
+            instance_double(VerifyToken, call: valid_verify_result),
+          )
+        end
+
+        it "allows access" do
+          get :test_action
+          expect(response).to have_http_status(:ok)
+        end
+      end
+
+      context "when the user's org has no permitted roles" do
+        let(:valid_verify_result) { VerifyToken::Result.new(valid: true, payload: {}, reason: nil) }
+        let(:current_user) { create(:user, organisation: create(:organisation, :without_roles)) }
+
+        before do
+          create(:session, user: current_user, token: plain_token, id_token: id_token_value)
+          session[:token] = plain_token
+          cookies[TradeTariffDevHub.id_token_cookie_name] = id_token_value
+          allow(VerifyToken).to receive(:new).with(id_token_value).and_return(
+            instance_double(VerifyToken, call: valid_verify_result),
+          )
+        end
+
+        it "clears authentication and redirects with a 'not yet open' alert", :aggregate_failures do
+          get :test_action
+          expect(response).to redirect_to("/")
+          expect(flash[:alert]).to include("not yet open to the public")
         end
       end
     end

--- a/spec/lib/trade_tariff_dev_hub_spec.rb
+++ b/spec/lib/trade_tariff_dev_hub_spec.rb
@@ -182,11 +182,18 @@ RSpec.describe TradeTariffDevHub do
       expect(described_class.allow_passwordless_self_service_org_creation?).to be(true)
     end
 
-    it "returns false in production even when self-service flag is enabled" do
+    it "returns false in production when the self-service flag is unset" do
+      ENV["ENVIRONMENT"] = "production"
+      ENV.delete("FEATURE_FLAG_SELF_SERVICE_ORG_CREATION")
+
+      expect(described_class.allow_passwordless_self_service_org_creation?).to be(false)
+    end
+
+    it "returns true in production when the self-service flag is enabled" do
       ENV["ENVIRONMENT"] = "production"
       ENV["FEATURE_FLAG_SELF_SERVICE_ORG_CREATION"] = "true"
 
-      expect(described_class.allow_passwordless_self_service_org_creation?).to be(false)
+      expect(described_class.allow_passwordless_self_service_org_creation?).to be(true)
     end
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe User, type: :model do
 
         user = described_class.find_by!(email_address: decoded_token["email"])
         expect(user.organisation.organisation_name).to eq(decoded_token["email"])
-        expect(user.organisation.roles).to be_empty
+        expect(user.organisation.roles.pluck(:name)).to eq(["trade_tariff:full"])
       end
     end
 

--- a/spec/services/associate_user_to_organisation_spec.rb
+++ b/spec/services/associate_user_to_organisation_spec.rb
@@ -94,13 +94,32 @@ RSpec.describe AssociateUserToOrganisation do
         allow(TradeTariffDevHub).to receive(:allow_passwordless_self_service_org_creation?).and_return(true)
       end
 
-      it "creates and associates an organisation without roles", :aggregate_failures do
+      it "creates and associates an organisation with the trade_tariff:full role", :aggregate_failures do
         expect { service.call(user) }.to change(Organisation, :count).by(1)
 
         expect(user).to be_persisted
         expect(user.organisation).to be_present
         expect(user.organisation.organisation_name).to eq("selfserve@example.com")
-        expect(user.organisation.roles).to be_empty
+        expect(user.organisation.roles.pluck(:name)).to eq(["trade_tariff:full"])
+      end
+    end
+
+    context "when the user joins an existing organisation via invitation" do
+      let(:user) { build(:user, organisation: nil, email_address: "invited@example.com") }
+      let(:inviter) { create(:user) }
+
+      before do
+        create(
+          :invitation,
+          invitee_email: user.email_address,
+          organisation: inviter.organisation,
+          status: :pending,
+          user: inviter,
+        )
+      end
+
+      it "does not mutate the existing organisation's roles" do
+        expect { service.call(user) }.not_to(change { inviter.organisation.reload.roles.pluck(:name).sort })
       end
     end
 


### PR DESCRIPTION
# Jira link

[OTTIMP-504](https://transformuk.atlassian.net/browse/OTTIMP-504)

Summary

- New self-service organisations are created with the trade_tariff:full role assigned in the same transaction.
- allow_passwordless_self_service_org_creation? now depends only on FEATURE_FLAG_SELF_SERVICE_ORG_CREATION — the hardcoded production block is gone, so enabling prod signups in ~2 weeks is a flag flip, not a deploy.
- handle_user_session lets trade_tariff:full orgs through the prod gate alongside fpo:full and admin.

Rollout
- Merge + deploy; prod flags unchanged (new signups stay blocked).
- Manually strip trade_tariff:full from existing prod orgs.
- In ~2 weeks, flip FEATURE_FLAG_SELF_SERVICE_ORG_CREATION=true and FEATURE_FLAG_ROLE_REQUEST=true in prod.
