### PR TITLE
BAU: Adds handling for deletion_enabled? after a revoke in production

### DIFF
--- a/app/views/trade_tariff_keys/index.html.erb
+++ b/app/views/trade_tariff_keys/index.html.erb
@@ -26,7 +26,7 @@
         row.with_cell do
           if trade_tariff_key.active?
             link_to 'Revoke', revoke_trade_tariff_key_path(trade_tariff_key.id), class: 'govuk-link'
-          else
+          elsif TradeTariffDevHub.deletion_enabled?
             link_to 'Delete', delete_trade_tariff_key_path(trade_tariff_key.id), class: 'govuk-link'
           end
         end


### PR DESCRIPTION
# Jira link

BAU

## What?

I have:

- [x] Added handling for rendering deletion urls when deletion is disabled

## Why?

I am doing this because:

- This blew up production just now
