### PR TITLE
Add GTM analytics with cookie consent to dev-hub

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,8 +1,10 @@
 # Dev Bypass Authentication (skip identity service)
+# Google Tag Manager container ID. Leave blank (or unset) to disable analytics locally.
 # IDENTITY_API_KEY=<bearer token from identity service>
 # IDENTITY_BASE_URL=http://localhost:3005
 # If unset, seeds create a stub key and the create flow will fail until set.
 # Optional: required only if you want to create real Trade Tariff keys (Cognito + API Gateway).
+# Set to GTM-KPM7NRDG when testing analytics integration.
 # TRADE_TARIFF_USAGE_PLAN_ID=<usage plan id from API Gateway - see docs/TRADE_TARIFF_KEYS_SETUP.md>
 AWS_DEFAULT_REGION=eu-west-2
 DELETION_ENABLED=true
@@ -13,6 +15,7 @@ ENCRYPTION_KEY=+WxrxtmkNdODyHrrwh1K2msWts1HVCCf7B98Q0odcUs=
 ENVIRONMENT=development
 FEATURE_FLAG_ROLE_REQUEST=true
 FEATURE_FLAG_SELF_SERVICE_ORG_CREATION=true
+GOOGLE_TAG_MANAGER_CONTAINER_ID=
 GOVUK_APP_DOMAIN='*'
 LOCALSTACK_HOST='host.docker.internal'
 PORT=3004

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,4 +1,55 @@
 class PagesController < ApplicationController
-  def cookies; end
+  def cookies_info
+    render :cookies
+  end
+
   def privacy; end
+
+  def cookies_policy
+    @current_usage_choice = current_usage_choice
+  end
+
+  def update_cookies_policy
+    usage_param = params[:usage].to_s
+    unless %w[true false].include?(usage_param)
+      redirect_to cookies_policy_path, alert: "Select whether to allow cookies that measure website use"
+      return
+    end
+    usage = usage_param == "true"
+
+    # httponly: false is required so the JS cookie banner in app/javascript/application.js
+    # can read the consent choice to decide which banner state to show. The same cookie is
+    # written from JS; without this, the server-side write would be readable only on the
+    # next request, not immediately after redirect.
+    cookies[TradeTariffDevHub::POLICY_COOKIE_NAME] = {
+      value: { usage: usage, remember_settings: usage }.to_json,
+      expires: 1.year.from_now,
+      path: "/",
+      same_site: :lax,
+      httponly: false,
+      secure: TradeTariffDevHub.deployed_environment?,
+    }
+
+    delete_analytics_cookies unless usage
+
+    redirect_to cookies_policy_path, notice: "Your cookie settings have been saved"
+  end
+
+private
+
+  def current_usage_choice
+    consent = AnalyticsConsent.from_cookie(cookies[TradeTariffDevHub::POLICY_COOKIE_NAME])
+    consent.usage_choice
+  end
+
+  def delete_analytics_cookies
+    request.cookies.each_key do |name|
+      next unless TradeTariffDevHub::ANALYTICS_COOKIE_PREFIXES.any? { |prefix| name.start_with?(prefix) }
+
+      cookies.delete(name, path: "/")
+      TradeTariffDevHub.analytics_cookie_delete_domains(request.host).each do |domain|
+        cookies.delete(name, path: "/", domain: domain)
+      end
+    end
+  end
 end

--- a/app/helpers/analytics_helper.rb
+++ b/app/helpers/analytics_helper.rb
@@ -1,0 +1,6 @@
+module AnalyticsHelper
+  def analytics_allowed?
+    consent = AnalyticsConsent.from_cookie(cookies[TradeTariffDevHub::POLICY_COOKIE_NAME])
+    consent.analytics_allowed?
+  end
+end

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,8 +1,136 @@
 // Configure your import map in config/importmap.rb. Read more: https://github.com/rails/importmap-rails
 import { initAll } from 'govuk-frontend'
 
+const ONE_YEAR_SECONDS = 60 * 60 * 24 * 365
+
+function metaContent(name) {
+  const el = document.querySelector('meta[name="' + name + '"]')
+  return el ? el.getAttribute('content') : null
+}
+
+// Names mirror the Ruby constants in TradeTariffDevHub. Fallbacks preserve behaviour
+// on pages rendered before the meta tags existed or if a meta tag is accidentally removed.
+const COOKIES_POLICY = metaContent('analytics-policy-cookie') || 'cookies_policy'
+const COOKIES_PREFERENCES_SET = metaContent('analytics-preferences-cookie') || 'cookies_preferences_set'
+const ANALYTICS_COOKIE_PREFIXES = (metaContent('analytics-cookie-prefixes') || '_ga,_gat,_gid')
+  .split(',')
+  .map((p) => p.trim())
+  .filter(Boolean)
+const ANALYTICS_COOKIE_DELETE_DOMAINS = (
+  metaContent('analytics-cookie-delete-domains') || fallbackAnalyticsCookieDeleteDomains()
+)
+  .split(',')
+  .map((d) => d.trim())
+  .filter(Boolean)
+
+function readCookie(name) {
+  const match = document.cookie.match(new RegExp('(?:^|; )' + name.replace(/[-.$?*|{}()[\]\\/+^]/g, '\\$&') + '=([^;]*)'))
+  return match ? decodeURIComponent(match[1]) : null
+}
+
+function writeCookie(name, value, maxAgeSeconds) {
+  const attrs = [
+    'path=/',
+    'max-age=' + maxAgeSeconds,
+    'SameSite=Lax',
+  ]
+  if (window.location.protocol === 'https:') attrs.push('Secure')
+  document.cookie = name + '=' + encodeURIComponent(value) + ';' + attrs.join(';')
+}
+
+function readCookiesPolicy() {
+  const raw = readCookie(COOKIES_POLICY)
+  if (!raw) return null
+  try {
+    return JSON.parse(raw)
+  } catch (_e) {
+    return null
+  }
+}
+
+function writeCookiesPolicy(policy) {
+  writeCookie(COOKIES_POLICY, JSON.stringify(policy), ONE_YEAR_SECONDS)
+}
+
+function fallbackAnalyticsCookieDeleteDomains() {
+  const host = window.location.hostname
+  const baseDomain = host.split('.').slice(-2).join('.')
+  return [host, '.' + host, '.' + baseDomain].join(',')
+}
+
+function deleteAnalyticsCookies() {
+  document.cookie.split(';').forEach((c) => {
+    const name = c.split('=')[0].trim()
+    if (!ANALYTICS_COOKIE_PREFIXES.some((prefix) => name.startsWith(prefix))) return
+
+    ANALYTICS_COOKIE_DELETE_DOMAINS.forEach((d) => {
+      document.cookie = name + '=; path=/; domain=' + d + '; expires=Thu, 01 Jan 1970 00:00:01 GMT'
+    })
+    document.cookie = name + '=; path=/; expires=Thu, 01 Jan 1970 00:00:01 GMT'
+  })
+}
+
+function initCookieBanner() {
+  const root = document.querySelector('[data-cookies-banner="root"]')
+  if (!root) return
+
+  const sections = {
+    ask: root.querySelector('[data-cookies-banner="ask"]'),
+    accepted: root.querySelector('[data-cookies-banner="accepted"]'),
+    rejected: root.querySelector('[data-cookies-banner="rejected"]'),
+  }
+
+  const show = (key) => {
+    root.hidden = false
+    Object.entries(sections).forEach(([name, el]) => {
+      if (!el) return
+      el.hidden = name !== key
+    })
+  }
+
+  const hide = () => {
+    root.hidden = true
+    Object.values(sections).forEach((el) => { if (el) el.hidden = true })
+  }
+
+  const policy = readCookiesPolicy()
+  const preferencesSet = readCookie(COOKIES_PREFERENCES_SET) === 'true'
+
+  if (!policy) {
+    show('ask')
+  } else if (!preferencesSet) {
+    show(policy.usage ? 'accepted' : 'rejected')
+  } else {
+    hide()
+  }
+
+  root.addEventListener('click', (event) => {
+    const target = event.target.closest('[data-cookies-banner-action]')
+    if (!target) return
+    event.preventDefault()
+    const action = target.getAttribute('data-cookies-banner-action')
+
+    if (action === 'accept') {
+      writeCookiesPolicy({ usage: true, remember_settings: true })
+      show('accepted')
+      // Reload so the server injects the GTM snippet on the next render. This is a
+      // deliberate choice over client-side GTM injection to keep a single (server-rendered,
+      // CSP-nonced) code path for the snippet. Cost is one extra request on first accept.
+      window.location.reload()
+    } else if (action === 'reject') {
+      writeCookiesPolicy({ usage: false, remember_settings: false })
+      deleteAnalyticsCookies()
+      show('rejected')
+    } else if (action === 'hide') {
+      writeCookie(COOKIES_PREFERENCES_SET, 'true', ONE_YEAR_SECONDS)
+      hide()
+    }
+  })
+}
+
 document.addEventListener('DOMContentLoaded', () => {
   initAll();
+  initCookieBanner();
 
   const legacyButton = document.getElementById('copy-to-clipboard')
   const legacyTarget = document.getElementById('api-key-secret')

--- a/app/lib/trade_tariff_dev_hub.rb
+++ b/app/lib/trade_tariff_dev_hub.rb
@@ -1,4 +1,17 @@
 module TradeTariffDevHub
+  # Name of the cookie that stores the user's analytics consent choice as JSON.
+  # Must stay in sync with the meta tag emitted in app/views/layouts/application.html.erb
+  # and the JS cookie banner in app/javascript/application.js.
+  POLICY_COOKIE_NAME = "cookies_policy".freeze
+
+  # Name of the cookie that tracks whether the user has dismissed the post-choice
+  # confirmation banner ("You have accepted/rejected additional cookies").
+  PREFERENCES_SET_COOKIE_NAME = "cookies_preferences_set".freeze
+
+  # Cookie name prefixes set by Google Analytics / Google Tag Manager. When a user
+  # revokes consent we clear any cookie whose name starts with one of these.
+  ANALYTICS_COOKIE_PREFIXES = %w[_ga _gat _gid].freeze
+
   class << self
     def govuk_app_domain
       @govuk_app_domain ||= ENV.fetch(
@@ -60,6 +73,19 @@ module TradeTariffDevHub
         "TERMS_AND_CONDITIONS_URL",
         "https://api.trade-tariff.service.gov.uk/fpo/terms-and-conditions.html",
       )
+    end
+
+    def google_tag_manager_container_id
+      ENV.fetch("GOOGLE_TAG_MANAGER_CONTAINER_ID", "")
+    end
+
+    def analytics_cookie_delete_domains(host)
+      return [] if host.blank?
+
+      domains = [host, ".#{host}"]
+      registrable_domain = host.split(".").last(2).join(".")
+      domains << ".#{registrable_domain}" if registrable_domain.present?
+      domains.uniq
     end
 
     def govuk_notifier_api_key

--- a/app/models/analytics_consent.rb
+++ b/app/models/analytics_consent.rb
@@ -1,0 +1,27 @@
+class AnalyticsConsent
+  attr_reader :usage
+
+  def self.from_cookie(raw_value)
+    return new(nil) if raw_value.blank?
+
+    parsed = JSON.parse(raw_value)
+    usage = parsed.key?("usage") ? ActiveModel::Type::Boolean.new.cast(parsed["usage"]) : nil
+    new(usage)
+  rescue JSON::ParserError, TypeError
+    new(nil)
+  end
+
+  def initialize(usage)
+    @usage = usage
+  end
+
+  def usage_choice
+    return nil if usage.nil?
+
+    !!usage
+  end
+
+  def analytics_allowed?
+    usage_choice == true
+  end
+end

--- a/app/views/layouts/_cookies_consent.html.erb
+++ b/app/views/layouts/_cookies_consent.html.erb
@@ -1,0 +1,76 @@
+<div data-cookies-banner="root" hidden>
+  <div data-cookies-banner="ask" hidden>
+    <div class="govuk-cookie-banner govuk-!-display-none-print" data-nosnippet role="region" aria-label="Cookies on the Developer Portal">
+      <div class="govuk-cookie-banner__message govuk-width-container">
+        <div class="govuk-grid-row">
+          <div class="govuk-grid-column-two-thirds">
+            <h2 class="govuk-cookie-banner__heading govuk-heading-m">Cookies on the Developer Portal</h2>
+            <div class="govuk-cookie-banner__content">
+              <p class="govuk-body">We use some essential cookies to make our services work.</p>
+              <p class="govuk-body">
+                We would like to set additional cookies so we can remember your settings,
+                understand how people use our services and make improvements.
+              </p>
+            </div>
+          </div>
+        </div>
+
+        <div class="govuk-button-group">
+          <button class="govuk-button" type="button" data-cookies-banner-action="accept">
+            Accept additional cookies
+          </button>
+          <button class="govuk-button" type="button" data-cookies-banner-action="reject">
+            Reject additional cookies
+          </button>
+          <%= link_to "View cookies", cookies_policy_path, class: "govuk-link" %>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div data-cookies-banner="accepted" hidden>
+    <div class="govuk-cookie-banner govuk-!-display-none-print" data-nosnippet role="region" aria-label="Cookies on the Developer Portal">
+      <div class="govuk-cookie-banner__message govuk-width-container">
+        <div class="govuk-grid-row">
+          <div class="govuk-grid-column-two-thirds">
+            <div class="govuk-cookie-banner__content">
+              <p class="govuk-body">
+                You have accepted additional cookies. You can
+                <%= link_to "change your cookie settings", cookies_policy_path, class: "govuk-link" %>
+                at any time.
+              </p>
+            </div>
+          </div>
+        </div>
+        <div class="govuk-button-group">
+          <button class="govuk-button" type="button" data-cookies-banner-action="hide">
+            Hide cookie message
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div data-cookies-banner="rejected" hidden>
+    <div class="govuk-cookie-banner govuk-!-display-none-print" data-nosnippet role="region" aria-label="Cookies on the Developer Portal">
+      <div class="govuk-cookie-banner__message govuk-width-container">
+        <div class="govuk-grid-row">
+          <div class="govuk-grid-column-two-thirds">
+            <div class="govuk-cookie-banner__content">
+              <p class="govuk-body">
+                You have rejected additional cookies. You can
+                <%= link_to "change your cookie settings", cookies_policy_path, class: "govuk-link" %>
+                at any time.
+              </p>
+            </div>
+          </div>
+        </div>
+        <div class="govuk-button-group">
+          <button class="govuk-button" type="button" data-cookies-banner-action="hide">
+            Hide cookie message
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,6 +1,9 @@
 <!DOCTYPE html>
 <html class="govuk-template--rebranded app-html-class">
   <head>
+    <% if analytics_allowed? && TradeTariffDevHub.google_tag_manager_container_id.present? %>
+      <%= render "shared/gtm", part: "head" %>
+    <% end %>
     <title><%= content_for(:title) || "UK Trade Tariff Developer Portal" %></title>
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
     <meta name="apple-mobile-web-app-capable" content="yes">
@@ -9,6 +12,11 @@
     <meta name="theme-color" content="#1d70b8">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
+
+    <meta name="analytics-policy-cookie" content="<%= TradeTariffDevHub::POLICY_COOKIE_NAME %>">
+    <meta name="analytics-preferences-cookie" content="<%= TradeTariffDevHub::PREFERENCES_SET_COOKIE_NAME %>">
+    <meta name="analytics-cookie-prefixes" content="<%= TradeTariffDevHub::ANALYTICS_COOKIE_PREFIXES.join(',') %>">
+    <meta name="analytics-cookie-delete-domains" content="<%= TradeTariffDevHub.analytics_cookie_delete_domains(request.host).join(',') %>">
 
     <%= favicon_link_tag 'favicon.ico' %>
     <%= favicon_link_tag 'favicon.svg' %>
@@ -26,6 +34,10 @@
   <% end %>
 
   <body class="govuk-template__body app-body-class">
+    <% if analytics_allowed? && TradeTariffDevHub.google_tag_manager_container_id.present? %>
+      <%= render "shared/gtm", part: "body" %>
+    <% end %>
+    <%= render "layouts/cookies_consent" %>
     <div class="govuk-width-container app-width-container">
     <script>document.body.className += ' js-enabled' + ('noModule' in HTMLScriptElement.prototype ? ' govuk-frontend-supported' : '');</script>
     <%= govuk_phase_banner(tag: { text: "Beta" }) do %>This is a new service, your

--- a/app/views/pages/cookies.html.erb
+++ b/app/views/pages/cookies.html.erb
@@ -1,38 +1,95 @@
-<h1 class="govuk-heading-xl">Cookies on the Commodity Code Identification Tool Developer Portal</h1>
+<h1 class="govuk-heading-xl">Cookies on the UK Trade Tariff Developer Portal</h1>
 <p class="govuk-body">Cookies are files saved on your phone, tablet or computer when you visit a website. We use cookies to store information about how you use this website, such as the pages you visit.</p>
 
+<p class="govuk-body">
+  You can
+  <%= link_to "change your cookie settings", cookies_policy_path, class: "govuk-link" %>
+  at any time.
+</p>
+
 <h2 class="govuk-heading-m">Strictly necessary cookies</h2>
-<p class="govuk-body">We only use strictly necessary cookies.</p>
 <p class="govuk-body">These essential cookies do things like remember your progress through the application. They always need to be on, or the service will not function.</p>
 
 <%= govuk_table do |table|
   table.with_head do |head|
     head.with_row do |row|
-      row.with_cell(header: true, text: 'Name')
-      row.with_cell(header: true, text: 'Purpose')
-      row.with_cell(header: true, text: 'Expires')
+      row.with_cell(header: true, text: "Name")
+      row.with_cell(header: true, text: "Purpose")
+      row.with_cell(header: true, text: "Expires")
     end
   end
 
   table.with_body do |body|
     body.with_row do |row|
-      row.with_cell(text: 'session')
-      row.with_cell(text: 'Stores details about your current login session')
-      row.with_cell(text: 'When you close your browser')
+      row.with_cell(text: "session")
+      row.with_cell(text: "Stores details about your current login session")
+      row.with_cell(text: "When you close your browser")
     end
 
     body.with_row do |row|
-      row.with_cell(text: 'session_sig')
+      row.with_cell(text: "session_sig")
       row.with_cell(text: "Stores a digital signature to ensure that the 'session' cookie hasn't been altered")
-      row.with_cell(text: 'When you close your browser')
+      row.with_cell(text: "When you close your browser")
     end
 
     body.with_row do |row|
-      row.with_cell(text: 'appSession.0, appSession.1, etc.')
+      row.with_cell(text: "appSession.0, appSession.1, etc.")
       row.with_cell(text: "Temporarily stores any information you provide while completing forms within the site")
-      row.with_cell(text: 'When you close your browser')
+      row.with_cell(text: "When you close your browser")
+    end
+
+    body.with_row do |row|
+      row.with_cell(text: "cookies_policy")
+      row.with_cell(text: "Saves your cookie consent choice")
+      row.with_cell(text: "1 year")
+    end
+
+    body.with_row do |row|
+      row.with_cell(text: "cookies_preferences_set")
+      row.with_cell(text: "Tracks whether you have dismissed the cookie confirmation message")
+      row.with_cell(text: "1 year")
     end
   end
 end %>
 
-<p class="govuk-body">Last updated 21 June 2024</p>
+<h2 class="govuk-heading-m">Cookies that measure website use</h2>
+<p class="govuk-body">With your permission, we use Google Tag Manager and Google Analytics to collect anonymised information about how you use this service. This helps us improve the Developer Portal.</p>
+<p class="govuk-body">These cookies are only set if you accept additional cookies.</p>
+
+<%= govuk_table do |table|
+  table.with_head do |head|
+    head.with_row do |row|
+      row.with_cell(header: true, text: "Name")
+      row.with_cell(header: true, text: "Purpose")
+      row.with_cell(header: true, text: "Expires")
+    end
+  end
+
+  table.with_body do |body|
+    body.with_row do |row|
+      row.with_cell(text: "_ga")
+      row.with_cell(text: "Identifies returning visitors so we can measure unique users")
+      row.with_cell(text: "2 years")
+    end
+
+    body.with_row do |row|
+      row.with_cell(text: "_ga_<container_id>")
+      row.with_cell(text: "Maintains session state for Google Analytics 4")
+      row.with_cell(text: "2 years")
+    end
+
+    body.with_row do |row|
+      row.with_cell(text: "_gid")
+      row.with_cell(text: "Identifies your browsing session so we can measure daily users")
+      row.with_cell(text: "24 hours")
+    end
+
+    body.with_row do |row|
+      row.with_cell(text: "_gat_*")
+      row.with_cell(text: "Used by Google Analytics to throttle the request rate")
+      row.with_cell(text: "1 minute")
+    end
+  end
+end %>
+
+<p class="govuk-body">Last updated 21 April 2026</p>

--- a/app/views/pages/cookies_policy.html.erb
+++ b/app/views/pages/cookies_policy.html.erb
@@ -1,0 +1,32 @@
+<h1 class="govuk-heading-xl">Change your cookie settings</h1>
+
+<p class="govuk-body">We use cookies to collect information about how you use the Developer Portal. We use this information to improve the service.</p>
+
+<%= form_with url: cookies_policy_path, method: :post, local: true, html: { novalidate: true } do |form| %>
+  <div class="govuk-form-group">
+    <fieldset class="govuk-fieldset" aria-describedby="usage-hint">
+      <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+        <h2 class="govuk-fieldset__heading">Cookies that measure website use</h2>
+      </legend>
+      <div id="usage-hint" class="govuk-hint">
+        We use Google Tag Manager and Google Analytics to measure how you use the Developer Portal so we can improve it.
+      </div>
+      <div class="govuk-radios" data-module="govuk-radios">
+        <div class="govuk-radios__item">
+          <%= form.radio_button :usage, "true", class: "govuk-radios__input", id: "usage-yes", checked: @current_usage_choice == true %>
+          <%= form.label :usage, "Use cookies that measure my website use", value: "true", class: "govuk-label govuk-radios__label", for: "usage-yes" %>
+        </div>
+        <div class="govuk-radios__item">
+          <%= form.radio_button :usage, "false", class: "govuk-radios__input", id: "usage-no", checked: @current_usage_choice == false %>
+          <%= form.label :usage, "Do not use cookies that measure my website use", value: "false", class: "govuk-label govuk-radios__label", for: "usage-no" %>
+        </div>
+      </div>
+    </fieldset>
+  </div>
+
+  <%= form.govuk_submit "Save cookie settings" %>
+<% end %>
+
+<p class="govuk-body">
+  <%= link_to "View cookies information", cookies_path, class: "govuk-link" %>
+</p>

--- a/app/views/shared/_gtm.html.erb
+++ b/app/views/shared/_gtm.html.erb
@@ -1,0 +1,12 @@
+<% if part == "head" %>
+  <%= javascript_tag nonce: true do %>
+    (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','<%= TradeTariffDevHub.google_tag_manager_container_id %>');
+  <% end %>
+<% else %>
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=<%= TradeTariffDevHub.google_tag_manager_container_id %>"
+    height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<% end %>

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -8,9 +8,21 @@ Rails.application.configure do
   config.content_security_policy do |policy|
     policy.default_src :self, :https
     policy.font_src    :self, :https, :data
-    policy.img_src     :self, :https, :data
+    policy.img_src     :self, :https, :data,
+                       "https://www.googletagmanager.com",
+                       "https://www.google-analytics.com",
+                       "https://*.google-analytics.com",
+                       "https://*.analytics.google.com"
     policy.object_src  :none
-    policy.script_src  :self, :https
+    policy.script_src  :self, :https,
+                       "https://www.googletagmanager.com",
+                       "https://www.google-analytics.com"
+    policy.connect_src :self,
+                       "https://www.google-analytics.com",
+                       "https://*.analytics.google.com",
+                       "https://*.googletagmanager.com",
+                       "https://*.google-analytics.com"
+    policy.frame_src   :self, "https://www.googletagmanager.com"
     policy.style_src   :self, :https
     # Specify URI for violation reports
     policy.report_uri "/csp-violation-report"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -79,7 +79,9 @@ Rails.application.routes.draw do
   end
 
   get :privacy, to: "pages#privacy"
-  get :cookies, to: "pages#cookies"
+  get :cookies, to: "pages#cookies_info"
+  get "/cookies-policy", to: "pages#cookies_policy", as: :cookies_policy
+  post "/cookies-policy", to: "pages#update_cookies_policy"
 
   post "/csp-violation-report", to: "csp_reports#create"
 

--- a/spec/helpers/analytics_helper_spec.rb
+++ b/spec/helpers/analytics_helper_spec.rb
@@ -1,0 +1,43 @@
+RSpec.describe AnalyticsHelper, type: :helper do
+  describe "#analytics_allowed?" do
+    context "when consent cookie has not been set" do
+      it { expect(helper.analytics_allowed?).to be false }
+    end
+
+    context "when consent cookie has been set" do
+      before do
+        allow(controller.cookies).to receive(:[]).with("cookies_policy").and_return(value)
+      end
+
+      context "when cookies have been accepted" do
+        let(:value) { { usage: true, remember_settings: true }.to_json.to_s }
+
+        it { expect(helper.analytics_allowed?).to be true }
+      end
+
+      context "when cookies have been rejected" do
+        let(:value) { { usage: false, remember_settings: true }.to_json.to_s }
+
+        it { expect(helper.analytics_allowed?).to be false }
+      end
+
+      context "when usage key is missing" do
+        let(:value) { { remember_settings: true }.to_json.to_s }
+
+        it { expect(helper.analytics_allowed?).to be false }
+      end
+
+      context "when usage is explicitly null" do
+        let(:value) { { usage: nil, remember_settings: true }.to_json.to_s }
+
+        it { expect(helper.analytics_allowed?).to be false }
+      end
+
+      context "when the cookie contains malformed JSON" do
+        let(:value) { "not-json" }
+
+        it { expect(helper.analytics_allowed?).to be false }
+      end
+    end
+  end
+end

--- a/spec/lib/trade_tariff_dev_hub_spec.rb
+++ b/spec/lib/trade_tariff_dev_hub_spec.rb
@@ -229,6 +229,40 @@ RSpec.describe TradeTariffDevHub do
     end
   end
 
+  describe ".google_tag_manager_container_id" do
+    before do
+      allow(ENV).to receive(:fetch).and_call_original
+    end
+
+    it "returns the GOOGLE_TAG_MANAGER_CONTAINER_ID env var when set" do
+      allow(ENV).to receive(:fetch).with("GOOGLE_TAG_MANAGER_CONTAINER_ID", "").and_return("GTM-KPM7NRDG")
+
+      expect(described_class.google_tag_manager_container_id).to eq("GTM-KPM7NRDG")
+    end
+
+    it "returns a blank string when GOOGLE_TAG_MANAGER_CONTAINER_ID is unset" do
+      allow(ENV).to receive(:fetch).with("GOOGLE_TAG_MANAGER_CONTAINER_ID", "").and_return("")
+
+      expect(described_class.google_tag_manager_container_id).to eq("")
+    end
+  end
+
+  describe ".analytics_cookie_delete_domains" do
+    it "returns host and domain variants for deleting analytics cookies" do
+      expect(described_class.analytics_cookie_delete_domains("hub.dev.trade-tariff.service.gov.uk")).to eq(
+        [
+          "hub.dev.trade-tariff.service.gov.uk",
+          ".hub.dev.trade-tariff.service.gov.uk",
+          ".gov.uk",
+        ],
+      )
+    end
+
+    it "returns an empty array when host is blank" do
+      expect(described_class.analytics_cookie_delete_domains(nil)).to eq([])
+    end
+  end
+
   describe ".live_production_environment?" do
     include_context "with restored ENVIRONMENT"
 

--- a/spec/models/analytics_consent_spec.rb
+++ b/spec/models/analytics_consent_spec.rb
@@ -1,0 +1,50 @@
+require "rails_helper"
+
+RSpec.describe AnalyticsConsent do
+  describe ".from_cookie" do
+    context "when cookie is missing" do
+      it "returns no selection and disallows analytics", :aggregate_failures do
+        consent = described_class.from_cookie(nil)
+
+        expect(consent.usage_choice).to be_nil
+        expect(consent.analytics_allowed?).to be false
+      end
+    end
+
+    context "when cookie has usage:true" do
+      it "returns usage true and allows analytics", :aggregate_failures do
+        consent = described_class.from_cookie({ usage: true }.to_json)
+
+        expect(consent.usage_choice).to be true
+        expect(consent.analytics_allowed?).to be true
+      end
+    end
+
+    context "when cookie has usage:false" do
+      it "returns usage false and disallows analytics", :aggregate_failures do
+        consent = described_class.from_cookie({ usage: false }.to_json)
+
+        expect(consent.usage_choice).to be false
+        expect(consent.analytics_allowed?).to be false
+      end
+    end
+
+    context "when usage key is missing" do
+      it "returns no selection and disallows analytics", :aggregate_failures do
+        consent = described_class.from_cookie({ remember_settings: true }.to_json)
+
+        expect(consent.usage_choice).to be_nil
+        expect(consent.analytics_allowed?).to be false
+      end
+    end
+
+    context "when cookie JSON is malformed" do
+      it "returns no selection and disallows analytics", :aggregate_failures do
+        consent = described_class.from_cookie("{")
+
+        expect(consent.usage_choice).to be_nil
+        expect(consent.analytics_allowed?).to be false
+      end
+    end
+  end
+end

--- a/spec/requests/pages_spec.rb
+++ b/spec/requests/pages_spec.rb
@@ -1,0 +1,120 @@
+require "rails_helper"
+
+RSpec.describe "Pages", type: :request do
+  describe "GET /cookies" do
+    it "renders the cookies page", :aggregate_failures do
+      get "/cookies"
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Cookies on the UK Trade Tariff Developer Portal")
+      expect(response.body).to include("Cookies that measure website use")
+    end
+  end
+
+  describe "GET /cookies-policy" do
+    it "renders the cookie settings form", :aggregate_failures do
+      get "/cookies-policy"
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Change your cookie settings")
+    end
+  end
+
+  describe "POST /cookies-policy" do
+    it "stores the usage:true choice when accepted", :aggregate_failures do
+      post "/cookies-policy", params: { usage: "true" }
+
+      expect(response).to redirect_to(cookies_policy_path)
+      expect(response.cookies["cookies_policy"]).to include("\"usage\":true")
+    end
+
+    it "stores the usage:false choice when rejected", :aggregate_failures do
+      post "/cookies-policy", params: { usage: "false" }
+
+      expect(response).to redirect_to(cookies_policy_path)
+      expect(response.cookies["cookies_policy"]).to include("\"usage\":false")
+    end
+
+    it "rejects unexpected usage values and does not set consent cookie", :aggregate_failures do
+      post "/cookies-policy", params: { usage: "yes-please" }
+
+      expect(response).to redirect_to(cookies_policy_path)
+      expect(flash[:alert]).to eq("Select whether to allow cookies that measure website use")
+      expect(response.cookies["cookies_policy"]).to be_nil
+    end
+
+    it "rejects missing usage values and does not set consent cookie", :aggregate_failures do
+      post "/cookies-policy", params: {}
+
+      expect(response).to redirect_to(cookies_policy_path)
+      expect(flash[:alert]).to eq("Select whether to allow cookies that measure website use")
+      expect(response.cookies["cookies_policy"]).to be_nil
+    end
+
+    # The cookies_policy cookie must be readable by application.js so the banner can
+    # reflect the user's current choice. Asserting on Set-Cookie attributes guards
+    # against a future regression that silently adds HttpOnly (which would break the JS).
+    it "sets SameSite=Lax and does not set HttpOnly on the cookies_policy cookie", :aggregate_failures do
+      post "/cookies-policy", params: { usage: "true" }
+
+      set_cookie_headers = Array(response.headers["Set-Cookie"]).flat_map { |h| h.split("\n") }
+      policy_header = set_cookie_headers.find { |h| h.start_with?("#{TradeTariffDevHub::POLICY_COOKIE_NAME}=") }
+
+      expect(policy_header).to be_present
+      expect(policy_header).to match(/;\s*SameSite=lax/i)
+      expect(policy_header).not_to match(/;\s*HttpOnly/i)
+    end
+  end
+
+  describe "GTM rendering in application layout" do
+    before do
+      allow(TradeTariffDevHub).to receive(:google_tag_manager_container_id).and_return("GTM-KPM7NRDG")
+    end
+
+    context "when no cookies_policy cookie is set" do
+      it "does not render the GTM snippet" do
+        get "/cookies"
+
+        expect(response.body).not_to include("googletagmanager.com")
+      end
+    end
+
+    context "when cookies_policy has usage:false" do
+      before do
+        cookies["cookies_policy"] = { usage: false, remember_settings: true }.to_json
+      end
+
+      it "does not render the GTM snippet" do
+        get "/cookies"
+
+        expect(response.body).not_to include("googletagmanager.com")
+      end
+    end
+
+    context "when cookies_policy has usage:true" do
+      before do
+        cookies["cookies_policy"] = { usage: true, remember_settings: true }.to_json
+      end
+
+      it "renders the GTM head script and the noscript iframe", :aggregate_failures do
+        get "/cookies"
+
+        expect(response.body).to include("googletagmanager.com/gtm.js")
+        expect(response.body).to include("googletagmanager.com/ns.html?id=GTM-KPM7NRDG")
+      end
+    end
+
+    context "when GTM container id is blank" do
+      before do
+        allow(TradeTariffDevHub).to receive(:google_tag_manager_container_id).and_return("")
+        cookies["cookies_policy"] = { usage: true, remember_settings: true }.to_json
+      end
+
+      it "does not render the GTM snippet even with consent" do
+        get "/cookies"
+
+        expect(response.body).not_to include("googletagmanager.com")
+      end
+    end
+  end
+end

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -5,27 +5,27 @@ Terraform to deploy the service into AWS.
 ## Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=1.12 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5 |
 
 ## Providers
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="provider_aws"></a> [aws](#provider\_aws) | 5.92.0 |
 
 ## Modules
 
 | Name | Source | Version |
-|------|--------|---------|
+| ---- | ------ | ------- |
 | <a name="module_dev-hub-job"></a> [dev-hub-job](#module\_dev-hub-job) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service | aws/ecs-service-v1.21.0 |
 | <a name="module_service"></a> [service](#module\_service) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service | aws/ecs-service-v1.21.0 |
 
 ## Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [aws_cloudwatch_event_rule.dev_hub_cleanup](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_rule) | resource |
 | [aws_cloudwatch_event_target.dev_hub_cleanup](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_target) | resource |
 | [aws_iam_policy.eventbridge_pass_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
@@ -57,7 +57,7 @@ Terraform to deploy the service into AWS.
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_cpu"></a> [cpu](#input\_cpu) | CPU units to use. | `number` | n/a | yes |
 | <a name="input_docker_tag"></a> [docker\_tag](#input\_docker\_tag) | Image tag to use. | `string` | n/a | yes |
 | <a name="input_enable_cleanup_job"></a> [enable\_cleanup\_job](#input\_enable\_cleanup\_job) | Whether to provision the scheduled ECS job (e.g. Playwright API key cleanup). Set per environment in config\_*.tfvars. | `bool` | `false` | no |


### PR DESCRIPTION
# Jira link

[OTTIMP-31](https://transformuk.atlassian.net/browse/OTTIMP-31)

## Summary

Adds Google Tag Manager (container `GTM-KPM7NRDG`) to every page of the dev-hub, gated by a GOV.UK-style cookie consent banner. Mirrors the pattern already used in `trade-tariff-frontend` so the `cookies_policy` cookie format and helper logic are consistent across the two apps.

## What's new

- `TradeTariffDevHub.google_tag_manager_container_id` reads `GOOGLE_TAG_MANAGER_CONTAINER_ID` from env.
- `AnalyticsHelper#analytics_allowed?` parses the `cookies_policy` cookie.
- `shared/_gtm.html.erb` renders the head loader (nonced to satisfy CSP) and the `<noscript>` iframe.
- `application.html.erb` injects the GTM snippet only when `analytics_allowed? && container id present`.
- GOV.UK cookie banner (`layouts/_cookies_consent.html.erb`) with plain-JS accept/reject/hide in `application.js` — no new npm deps.
- `/cookies-policy` settings page (GET form + POST update) for a no-JS fallback, plus updated `/cookies` page listing the GA/GTM cookies.
- CSP extended to explicitly allow `googletagmanager.com` and `google-analytics.com` for `script_src`, `img_src`, `connect_src`, and `frame_src` (still `report_only`).

## Deployment

- Add `GOOGLE_TAG_MANAGER_CONTAINER_ID=GTM-KPM7NRDG` to the dev-hub secret in AWS Secrets Manager for staging and production. No Terraform change needed — it's picked up via `secret_env_vars` in `terraform/locals.tf`.
- Locally the variable is left blank in `.env.development`; the layout's `present?` guard means GTM is skipped when unset.

## Follow-up (GTM dashboard, not code)

Most requested metrics (page views, unique users, traffic sources, entry/exit, time on page, repeat visits) work out of the box once a GA4 tag is attached to the container. "Clicks on key links" needs Enhanced Measurement outbound-click tracking enabled in GA4, or a Link Click trigger configured inside GTM.
