### PR TITLE
Add suffix to external links in views

### DIFF
--- a/app/views/api_keys/index.html.erb
+++ b/app/views/api_keys/index.html.erb
@@ -39,5 +39,5 @@ end %>
 <%= govuk_button_link_to('Create new key', new_api_key_path, secondary: true) %>
 
 <h2 class="govuk-heading-m">If you need help</h2>
-<p class="govuk-body">Information and guidance in <%= govuk_link_to 'the FPO API', 'https://docs.dev.trade-tariff.service.gov.uk/fpo.html', target: '_blank' %>.</p>
-<p class="govuk-body">If you have any further queries relating to the developer portal, <%= govuk_link_to 'use the enquiry form', 'https://www.trade-tariff.service.gov.uk/enquiry_form', target: '_blank' %>.</p>
+<p class="govuk-body">Information and guidance in <%= govuk_link_to 'the FPO API (Opens in new tab)', 'https://docs.dev.trade-tariff.service.gov.uk/fpo.html', target: '_blank', rel: 'noreferrer noopener' %>.</p>
+<p class="govuk-body">If you have any further queries relating to the developer portal, <%= govuk_link_to 'use the enquiry form (Opens in new tab)', 'https://www.trade-tariff.service.gov.uk/enquiry_form', target: '_blank', rel: 'noreferrer noopener' %>.</p>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -29,7 +29,7 @@
     <div class="govuk-width-container app-width-container">
     <script>document.body.className += ' js-enabled' + ('noModule' in HTMLScriptElement.prototype ? ' govuk-frontend-supported' : '');</script>
     <%= govuk_phase_banner(tag: { text: "Beta" }) do %>This is a new service, your
-      <%= govuk_link_to("feedback (opens in a new tab)", ENV["FEEDBACK_URL"] || 'https://www.trade-tariff.service.gov.uk/feedback', target: "_blank") %>
+      <%= govuk_link_to("feedback (Opens in new tab)", ENV["FEEDBACK_URL"] || 'https://www.trade-tariff.service.gov.uk/feedback', target: "_blank", rel: "noreferrer noopener") %>
       will help us improve it.
     <% end %>
     <% if content_for?(:back_link) %>

--- a/app/views/organisations/show.html.erb
+++ b/app/views/organisations/show.html.erb
@@ -127,6 +127,6 @@
   <div class="govuk-grid-column-two-thirds">
     <h2 class="govuk-heading-m">If you need help</h2>
     <p class="govuk-body">Information and guidance in <%= documentation_link %>.</p>
-    <p class="govuk-body">If you have any further queries relating to the developer portal, <%= govuk_link_to 'use the enquiry form', 'https://www.trade-tariff.service.gov.uk/enquiry_form', target: '_blank' %>.</p>
+    <p class="govuk-body">If you have any further queries relating to the developer portal, <%= govuk_link_to 'use the enquiry form (Opens in new tab)', 'https://www.trade-tariff.service.gov.uk/enquiry_form', target: '_blank', rel: 'noreferrer noopener' %>.</p>
   </div>
 </div>

--- a/app/views/pages/privacy.html.erb
+++ b/app/views/pages/privacy.html.erb
@@ -131,15 +131,15 @@ at: <%= govuk_link_to "advice.dpa@hmrc.gov.uk", "mailto:advice.dpa@hmrc.gov.uk" 
 </p>
 
 <p class="govuk-body">
-  You can read more about how the <abbr title="Data Protection Officer">DPO</abbr> handles your personal information in our <%= govuk_link_to "Office of the Data Protection Officer Privacy Notice", "https://www.gov.uk/government/publications/hmrc-office-of-the-data-protection-officer-privacy-notice" %>
+  You can read more about how the <abbr title="Data Protection Officer">DPO</abbr> handles your personal information in our <%= govuk_link_to "Office of the Data Protection Officer Privacy Notice (Opens in new tab)", "https://www.gov.uk/government/publications/hmrc-office-of-the-data-protection-officer-privacy-notice", target: "_blank", rel: "noreferrer noopener" %>
 </p>
 
 <p class="govuk-body">
-  If you want to request a copy of your personal data follow HMRC’s <%= govuk_link_to "subject access request guidance", "https://www.gov.uk/guidance/hmrc-subject-access-request" %>.
+  If you want to request a copy of your personal data follow HMRC’s <%= govuk_link_to "subject access request guidance (Opens in new tab)", "https://www.gov.uk/guidance/hmrc-subject-access-request", target: "_blank", rel: "noreferrer noopener" %>.
 </p>
 
 <p class="govuk-body">
-  You should follow the existing complaints process if you want to <%= govuk_link_to "complain about HMRC", "https://www.gov.uk/government/organisations/hm-revenue-customs/contact/complain-about-hmrc" %>
+  You should follow the existing complaints process if you want to <%= govuk_link_to "complain about HMRC (Opens in new tab)", "https://www.gov.uk/government/organisations/hm-revenue-customs/contact/complain-about-hmrc", target: "_blank", rel: "noreferrer noopener" %>
 </p>
 
 <p class="govuk-body">

--- a/app/views/trade_tariff_keys/index.html.erb
+++ b/app/views/trade_tariff_keys/index.html.erb
@@ -38,5 +38,5 @@ end %>
 <%= govuk_button_link_to('Create new Trade Tariff key', new_trade_tariff_key_path, secondary: true) %>
 
 <h2 class="govuk-heading-m">If you need help</h2>
-<p class="govuk-body">Information and guidance in <%= documentation_link %>.</p>
-<p class="govuk-body">If you have any further queries relating to the developer portal, <%= govuk_link_to 'use the enquiry form', 'https://www.trade-tariff.service.gov.uk/enquiry_form', target: '_blank' %>.</p>
+<p class="govuk-body">Information and guidance in <%= govuk_link_to 'the Trade Tariff API (Opens in new tab)', 'https://docs.dev.trade-tariff.service.gov.uk/the-trade-tariff-api.html', target: '_blank', rel: 'noreferrer noopener' %>.</p>
+<p class="govuk-body">If you have any further queries relating to the developer portal, <%= govuk_link_to 'use the enquiry form (Opens in new tab)', 'https://www.trade-tariff.service.gov.uk/enquiry_form', target: '_blank', rel: 'noreferrer noopener' %>.</p>


### PR DESCRIPTION
# Jira link

[OTTIMP-521](https://transformuk.atlassian.net/browse/OTTIMP-521)

## Summary

Apply GOV.UK accessibility convention to every external absolute https link rendered from ERB views so they:
- open in a new tab (`target="_blank"`)
- include `rel="noreferrer noopener"` for security
- have a visible `(Opens in a new tab)` suffix inside the link text (announced by screen readers)

Links to the excluded `api.trade-tariff.service.gov.uk` host, relative paths, `mailto:` links, internal RFCs, and Ruby helpers/config are untouched. Scope was limited to views per the agreed plan; `ApplicationHelper` link helpers and `govuk_footer` `meta_items` are left for a follow-up.

## Files changed
- `app/views/pages/privacy.html.erb` — 3 × `www.gov.uk` links (DPO privacy notice, subject access request guidance, complain about HMRC): added `target`, `rel`, and suffix.
- `app/views/api_keys/index.html.erb` — FPO API docs and enquiry form: added `rel` and suffix (already had `target`).
- `app/views/trade_tariff_keys/index.html.erb` — Trade Tariff API docs and enquiry form: added `rel` and suffix.
- `app/views/organisations/show.html.erb` — enquiry form: added `rel` and suffix.
- `app/views/layouts/application.html.erb` — phase-banner feedback link: normalised `(opens in a new tab)` → `(Opens in a new tab)` and added `rel`.
