### PR TITLE
Use HTTPS (8443) to reach backend-uk from dev-hub

### DIFF
--- a/app/lib/trade_tariff_dev_hub.rb
+++ b/app/lib/trade_tariff_dev_hub.rb
@@ -246,7 +246,7 @@ module TradeTariffDevHub
     end
 
     def uk_backend_url
-      @uk_backend_url ||= ENV.fetch("UK_BACKEND_URL", "http://backend-uk.tariff.internal:8080/uk/api")
+      @uk_backend_url ||= ENV.fetch("UK_BACKEND_URL", "https://backend-uk.tariff.internal:8443/uk/api")
     end
 
     def uk_backend_bearer_token

--- a/app/services/send_notification.rb
+++ b/app/services/send_notification.rb
@@ -56,6 +56,8 @@ private
         conn.response :json
         conn.ssl.verify = false
         conn.ssl.ca_file = cert_path
+        conn.options.open_timeout = 5
+        conn.options.timeout = 5
         conn.headers["User-Agent"] = user_agent
         conn.headers["Accept"] = ACCEPT
         conn.headers["Authorization"] = "Bearer #{TradeTariffDevHub.uk_backend_bearer_token}"


### PR DESCRIPTION
# Jira link

[OTTIMP-527](https://transformuk.atlassian.net/browse/OTTIMP-527)

Since HMRC-1965 was deployed (dev + staging on 21 Apr, prod on 16 Apr), backend-uk no longer listens on port 8080 and the shared ECS security group no longer allows 8080 ingress. Dev-hub's SendNotification still targets http://backend-uk.tariff.internal:8080/uk/api, so every outbound notification call silently hangs on TCP connect until Ruby's default 60s open_timeout fires.

User-visible impact:

POST /role_requests hangs ~60s, browser/CloudFront time out before the redirect arrives. The row is saved, so a page refresh appears to "work".
Admin approve/reject of role requests and admin invitations raise a 500 after 60s (no rescue on those paths).
Acceptance criteria:

Default UK_BACKEND_URL in trade-tariff-dev-hub points at https://backend-uk.tariff.internal:8443/uk/api.
Faraday client in SendNotification has a short (≤5s) open/read timeout.
Verified in staging: submitting a role request redirects promptly with the success flash; notification lands in GOV.UK Notify for the configured admin recipients.
No regression to local dev (.env.development override still points at local backend on port 3000).