### PR TITLE
OTTIMP-544: Hide secret column for trade tariff keys in shared key table

### DIFF
--- a/app/views/shared/_keys_table.html.erb
+++ b/app/views/shared/_keys_table.html.erb
@@ -1,10 +1,11 @@
 <% secret_display = local_assigns.fetch(:secret_display, :masked) %>
+<% show_secret_column = secret_display != :not_stored %>
 <%= govuk_table do |table| %>
   <% table.with_head do |head| %>
     <% head.with_row do |row| %>
       <% row.with_cell(text: headers[:description]) %>
       <% row.with_cell(text: headers[:identifier]) %>
-      <% row.with_cell(text: 'Secret') %>
+      <% row.with_cell(text: 'Secret') if show_secret_column %>
       <% row.with_cell(text: 'Status') %>
       <% row.with_cell(text: 'Created') %>
       <% row.with_cell(text: 'Actions') %>
@@ -16,11 +17,8 @@
       <% body.with_row do |row| %>
         <% row.with_cell(header: true, text: key.description) %>
         <% row.with_cell(text: identifier_callable.call(key)) %>
-        <% row.with_cell do %>
-          <% if secret_display == :not_stored %>
-            <span class="govuk-body-s govuk-!-margin-bottom-0"
-                  title="The client secret is only shown once when you create the key. It is not stored in Dev Hub.">Not stored</span>
-          <% else %>
+        <% if show_secret_column %>
+          <% row.with_cell do %>
             <%= render 'shared/masked_secret_toggle', record: key, prefix: secret_prefix %>
           <% end %>
         <% end %>


### PR DESCRIPTION
# Jira link

[OTTIMP-544](https://transformuk.atlassian.net/browse/OTTIMP-544)

## What?

I have:

- Remove the secret column from trade tariff key listings in organisation and admin views.
- Keep existing secret display behavior unchanged for key types that still expose secrets.