### PR TITLE
OTTIMP-543 Fix pagination and searching for admin org page

### DIFF
--- a/app/controllers/admin/organisations_controller.rb
+++ b/app/controllers/admin/organisations_controller.rb
@@ -2,6 +2,8 @@ class Admin::OrganisationsController < Admin::BaseController
   include Pagy::Backend
 
   def index
+    @search_query = params[:q].to_s.strip
+
     @sort_column = params[:sort].presence || "created_at"
     @sort_direction = params[:direction].presence || "desc"
 
@@ -12,11 +14,15 @@ class Admin::OrganisationsController < Admin::BaseController
     # Map 'name' to 'organisation_name' for the database column
     db_column = @sort_column == "name" ? "organisation_name" : @sort_column
 
+    scope = Organisation.includes(:users, :api_keys, :trade_tariff_keys, :invitations, :roles)
+    scope = scope.matching_name(@search_query) if @search_query.present?
+    scope = scope.order(db_column => @sort_direction.to_sym)
+
     @pagy, @organisations = pagy(
-      Organisation.includes(:users, :api_keys, :trade_tariff_keys, :invitations, :roles)
-                  .order(db_column => @sort_direction.to_sym),
+      scope,
       page: params[:page],
-      items: 20,
+      limit: TradeTariffDevHub::ADMIN_PAGY_PAGE_SIZE,
+      params: pagy_index_params,
     )
   end
 
@@ -35,5 +41,15 @@ class Admin::OrganisationsController < Admin::BaseController
     @api_keys = @organisation.api_keys
     @trade_tariff_keys = @organisation.trade_tariff_keys
     @invitations = @organisation.invitations.reject(&:accepted?)
+  end
+
+private
+
+  def pagy_index_params
+    {
+      q: @search_query.presence,
+      sort: params[:sort].presence_in(%w[name created_at]),
+      direction: params[:direction].presence_in(%w[asc desc]),
+    }.compact
   end
 end

--- a/app/controllers/admin/role_requests_controller.rb
+++ b/app/controllers/admin/role_requests_controller.rb
@@ -12,7 +12,7 @@ class Admin::RoleRequestsController < Admin::BaseController
                   .includes(:organisation, :user)
                   .order(created_at: :desc),
       page: params[:page],
-      items: 20,
+      limit: TradeTariffDevHub::ADMIN_PAGY_PAGE_SIZE,
     )
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,5 +1,6 @@
 module ApplicationHelper
   include Pagy::Frontend
+  include GovukPagyHelper
 
   def documentation_link
     govuk_link_to "API documentation (opens in new tab)", TradeTariffDevHub.documentation_url, target: "_blank"

--- a/app/helpers/govuk_pagy_helper.rb
+++ b/app/helpers/govuk_pagy_helper.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+# GOV.UK Design System pagination markup (see https://design-system.service.gov.uk/components/pagination/)
+# wired to Pagy, replacing the default pagy_nav HTML which does not match GDS styling.
+module GovukPagyHelper
+  def govuk_pagy_nav(pagy)
+    return "".html_safe if pagy.pages <= 1
+
+    content_tag(:nav, class: "govuk-pagination govuk-!-margin-top-6", role: "navigation", "aria-label": "Pagination") do
+      safe_join(
+        [
+          govuk_pagy_prev(pagy),
+          govuk_pagy_page_list(pagy),
+          govuk_pagy_next(pagy),
+        ].compact_blank,
+      )
+    end
+  end
+
+private
+
+  def govuk_pagy_prev(pagy)
+    return if pagy.prev.blank?
+
+    content_tag(:div, class: "govuk-pagination__prev") do
+      link_to(
+        pagy_url_for(pagy, pagy.prev),
+        class: "govuk-link govuk-pagination__link",
+        rel: "prev",
+      ) do
+        tag.span(class: "govuk-pagination__link-label") do
+          safe_join(["Previous ", tag.span("page", class: "govuk-visually-hidden")])
+        end
+      end
+    end
+  end
+
+  def govuk_pagy_next(pagy)
+    return if pagy.next.blank?
+
+    content_tag(:div, class: "govuk-pagination__next") do
+      link_to(
+        pagy_url_for(pagy, pagy.next),
+        class: "govuk-link govuk-pagination__link",
+        rel: "next",
+      ) do
+        tag.span(class: "govuk-pagination__link-label") do
+          safe_join(["Next ", tag.span("page", class: "govuk-visually-hidden")])
+        end
+      end
+    end
+  end
+
+  def govuk_pagy_page_list(pagy)
+    series = pagy.series
+    return if series.empty?
+
+    content_tag(:ul, class: "govuk-pagination__list") do
+      safe_join(
+        series.map { |item| govuk_pagy_series_item(pagy, item) },
+      )
+    end
+  end
+
+  def govuk_pagy_series_item(pagy, item)
+    case item
+    when :gap
+      content_tag(:li, class: "govuk-pagination__item govuk-pagination__item--ellipsis", "aria-hidden": "true") do
+        tag.span("⋯", class: "govuk-pagination__link-title")
+      end
+    when String
+      label = pagy.label_for(item)
+      content_tag(:li, class: "govuk-pagination__item govuk-pagination__item--current") do
+        link_to(
+          label,
+          pagy_url_for(pagy, item.to_i),
+          class: "govuk-pagination__link",
+          aria: { current: "page" },
+          "aria-label": "Page #{label}",
+        )
+      end
+    else
+      content_tag(:li, class: "govuk-pagination__item") do
+        link_to(
+          item,
+          pagy_url_for(pagy, item),
+          class: "govuk-link govuk-pagination__link",
+          "aria-label": "Page #{item}",
+        )
+      end
+    end
+  end
+end

--- a/app/lib/trade_tariff_dev_hub.rb
+++ b/app/lib/trade_tariff_dev_hub.rb
@@ -1,4 +1,8 @@
 module TradeTariffDevHub
+  # Page size for Pagy-backed admin lists. Passed explicitly to `pagy(..., limit: ...)` so it
+  # cannot silently fall back to Pagy’s built-in default (20 on Pagy 9).
+  ADMIN_PAGY_PAGE_SIZE = 10
+
   # Name of the cookie that stores the user's analytics consent choice as JSON.
   # Must stay in sync with the meta tag emitted in app/views/layouts/application.html.erb
   # and the JS cookie banner in app/javascript/application.js.

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -17,6 +17,14 @@
 class Organisation < ApplicationRecord
   ORGANISATION_NAME_EMAIL_LIKE_FORMAT = /\A#{URI::MailTo::EMAIL_REGEXP.source}\z/io
 
+  scope :matching_name, lambda { |term|
+    stripped = term.to_s.strip
+    next all if stripped.blank?
+
+    pattern = "%#{sanitize_sql_like(stripped)}%"
+    where("organisation_name ILIKE ?", pattern)
+  }
+
   has_paper_trail
 
   has_many :users, dependent: :destroy

--- a/app/views/admin/organisations/index.html.erb
+++ b/app/views/admin/organisations/index.html.erb
@@ -3,49 +3,76 @@
     <div class="govuk-grid-column-full">
       <h1 class="govuk-heading-l">All organisations</h1>
 
-      <%= govuk_table do |table|
-        table.with_head do |head|
-          head.with_row do |row|
-            row.with_cell do
-              sort_link_for('Name', 'name', current_column: @sort_column, current_direction: @sort_direction)
-            end
-            row.with_cell(text: 'Roles')
-            row.with_cell(text: 'Users')
-            row.with_cell(text: 'API Keys')
-            row.with_cell(text: 'Trade Tariff Keys')
-            row.with_cell(text: 'Invitations')
-            row.with_cell do
-              sort_link_for('Created', 'created_at', current_column: @sort_column, current_direction: @sort_direction)
-            end
-            row.with_cell(text: '')
-          end
-        end
+      <%= form_with url: admin_organisations_path, method: :get, local: true, html: { class: "govuk-!-margin-bottom-6" } do %>
+        <% unless @sort_column == "created_at" && @sort_direction == "desc" %>
+          <%= hidden_field_tag :sort, @sort_column %>
+          <%= hidden_field_tag :direction, @sort_direction %>
+        <% end %>
+        <div class="govuk-form-group govuk-!-margin-bottom-2">
+          <label class="govuk-label" for="admin-organisations-search-q">
+            Search by organisation name
+          </label>
+          <div id="admin-organisations-search-hint" class="govuk-hint">
+            You can use part of a name. Matching is not case-sensitive.
+          </div>
+          <%= text_field_tag :q,
+                             @search_query,
+                             id: "admin-organisations-search-q",
+                             class: "govuk-input govuk-!-width-one-third",
+                             "aria-describedby": "admin-organisations-search-hint" %>
+        </div>
+        <%= submit_tag "Search", name: nil, class: "govuk-button" %>
+      <% end %>
 
-        @organisations.each do |org|
-          table.with_body do |body|
-            body.with_row do |row|
-              row.with_cell(header: true, text: org.organisation_name)
+      <% if @organisations.any? %>
+        <%= govuk_table do |table|
+          table.with_head do |head|
+            head.with_row do |row|
               row.with_cell do
-                if org.roles.any?
-                  org.roles.sort_by(&:name).map(&:name).join(', ')
-                else
-                  content_tag(:span, 'None', class: 'govuk-hint')
+                sort_link_for('Name', 'name', current_column: @sort_column, current_direction: @sort_direction)
+              end
+              row.with_cell(text: 'Roles')
+              row.with_cell(text: 'Users')
+              row.with_cell(text: 'API Keys')
+              row.with_cell(text: 'Trade Tariff Keys')
+              row.with_cell(text: 'Invitations')
+              row.with_cell do
+                sort_link_for('Created', 'created_at', current_column: @sort_column, current_direction: @sort_direction)
+              end
+              row.with_cell(text: '')
+            end
+          end
+
+          @organisations.each do |org|
+            table.with_body do |body|
+              body.with_row do |row|
+                row.with_cell(header: true, text: org.organisation_name)
+                row.with_cell do
+                  if org.roles.any?
+                    org.roles.sort_by(&:name).map(&:name).join(', ')
+                  else
+                    content_tag(:span, 'None', class: 'govuk-hint')
+                  end
+                end
+                row.with_cell(text: org.users.size)
+                row.with_cell(text: org.api_keys.size)
+                row.with_cell(text: org.trade_tariff_keys.size)
+                row.with_cell(text: org.invitations.pending.size)
+                row.with_cell(text: org.created_at.strftime('%d %b %Y'))
+                row.with_cell do
+                  link_to 'View', admin_organisation_path(org), class: 'govuk-link'
                 end
               end
-              row.with_cell(text: org.users.count)
-              row.with_cell(text: org.api_keys.count)
-              row.with_cell(text: org.trade_tariff_keys.count)
-              row.with_cell(text: org.invitations.pending.count)
-              row.with_cell(text: org.created_at.strftime('%d %b %Y'))
-              row.with_cell do
-                link_to 'View', admin_organisation_path(org), class: 'govuk-link'
-              end
             end
           end
-        end
-      end %>
+        end %>
 
-      <%== pagy_nav(@pagy) if @pagy.pages > 1 %>
+        <%= govuk_pagy_nav(@pagy) if @pagy.pages > 1 %>
+      <% elsif @search_query.present? %>
+        <p class="govuk-body">No organisations match your search.</p>
+      <% else %>
+        <p class="govuk-body">There are no organisations.</p>
+      <% end %>
     </div>
   </div>
 </div>

--- a/app/views/admin/role_requests/index.html.erb
+++ b/app/views/admin/role_requests/index.html.erb
@@ -43,7 +43,7 @@
           end
         end %>
 
-        <%== pagy_nav(@pagy) if @pagy.pages > 1 %>
+        <%= govuk_pagy_nav(@pagy) if @pagy.pages > 1 %>
       <% else %>
         <p class="govuk-body">There are no pending access requests.</p>
       <% end %>

--- a/config/initializers/pagy.rb
+++ b/config/initializers/pagy.rb
@@ -1,2 +1,11 @@
-Pagy::DEFAULT[:items] = 20
-Pagy::DEFAULT[:size] = [1, 4, 4, 1]
+# Pagy 9+ uses :limit for page size (not :items). See https://ddnexus.github.io/pagy/docs/api/pagy/
+Pagy::DEFAULT[:limit] = TradeTariffDevHub::ADMIN_PAGY_PAGE_SIZE
+
+# Integer: number of page links in the sliding window (not a legacy array).
+Pagy::DEFAULT[:size] = 7
+
+# In development, code reload can run before initializers; keep DEFAULT aligned on each boot/reload.
+Rails.application.config.to_prepare do
+  Pagy::DEFAULT[:limit] = TradeTariffDevHub::ADMIN_PAGY_PAGE_SIZE
+  Pagy::DEFAULT[:size] = 7
+end

--- a/spec/requests/admin/organisations_spec.rb
+++ b/spec/requests/admin/organisations_spec.rb
@@ -5,6 +5,45 @@ RSpec.describe "Admin::Organisations", type: :request do
   let(:current_user) { create(:user, organisation: admin_organisation) }
   let(:other_organisation) { create(:organisation) }
 
+  describe "GET /admin/organisations" do
+    it "filters organisations by a case-insensitive partial name", :aggregate_failures do
+      matching_org = create(:organisation, organisation_name: "Acme Importers")
+      create(:organisation, organisation_name: "Delta Services")
+
+      get admin_organisations_path, params: { q: "acme" }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include(matching_org.organisation_name)
+      expect(response.body).not_to include("Delta Services")
+      expect(response.body).to include('value="acme"')
+    end
+
+    it "falls back to default sort when sort params are invalid", :aggregate_failures do
+      older_org = create(:organisation, organisation_name: "Older Org", created_at: 2.days.ago)
+      newer_org = create(:organisation, organisation_name: "Newer Org", created_at: 1.day.ago)
+
+      get admin_organisations_path, params: { sort: "unsafe", direction: "sideways" }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body.index(newer_org.organisation_name)).to be < response.body.index(older_org.organisation_name)
+      expect(response.body).to include("direction=asc&amp;sort=name")
+      expect(response.body).to include("direction=asc&amp;sort=created_at")
+    end
+
+    it "preserves search and sorting parameters in pagination links", :aggregate_failures do
+      (TradeTariffDevHub::ADMIN_PAGY_PAGE_SIZE + 1).times do |index|
+        create(:organisation, organisation_name: "Acme #{index}")
+      end
+
+      get admin_organisations_path, params: { q: "Acme", sort: "name", direction: "asc" }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to match(
+        %r{href="[^"]*\?(?=[^"]*q=Acme)(?=[^"]*sort=name)(?=[^"]*direction=asc)(?=[^"]*page=2)[^"]*"},
+      )
+    end
+  end
+
   describe "GET /admin/organisations/:id" do
     it "renders GOV.UK back link to organisations index", :aggregate_failures do
       get admin_organisation_path(other_organisation)


### PR DESCRIPTION
# Jira link

[OTTIMP-543](https://transformuk.atlassian.net/browse/OTTIMP-543)

## What?

Improves /admin/organisations when many organisations exist by keeping filtering and pagination on the server and reflecting state in the query string.

Changes
- Pagination: Uses existing Pagy setup with 10 items per page (was 20 on this screen). Page links keep page in the URL together with sort params.
- Search: GET form with q for partial, case-insensitive match on organisation_name (PostgreSQL ILIKE), with SQL LIKE wildcards escaped via sanitize_sql_like.
- Combined behaviour: Search narrows the relation before Pagy runs; pagination links preserve q, sort, and direction via pagy_index_params. Submitting search does not send page, so results start at page 1 again.
- UX: GOV.UK-style label, hint, input, and primary Search button; empty copy when no rows match the current search (and a generic empty message when there are no organisations at all).
- Model: Adds Organisation.matching_name scope used by the admin index.
