### PR TITLE
HMRC-2198: Label PRs that touch database schema with 'needs-deployment'

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,4 @@
+# Add "needs-deployment" label to pull requests making database schema changes
+needs-deployment:
+  - changed-files:
+    - any-glob-to-any-file: "db/*"

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,15 @@
+name: "Label PRs"
+
+on:
+  - pull_request_target
+
+jobs:
+  labeler:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - uses: actions/labeler@v6


### PR DESCRIPTION
### Jira link

[HMRC-2198](https://transformuk.atlassian.net/browse/HMRC-2198)

### What?

I have:

- Added the PR labelling workflow from [`trade-tariff-backend#3101`](https://github.com/trade-tariff/trade-tariff-backend/pull/3101)

### Why?

I am doing this because:

- We need to deploy any schema changes against the development environment to test that they work and don't introduce regressions
