### PR TITLE
OTTIMP-548: Fix cookie banner stacking: render consent above header

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -28,16 +28,15 @@
     <%= javascript_importmap_tags %>
   </head>
 
-  <%= govuk_header(homepage_url: ENV.fetch("GOVUK_APP_DOMAIN", "http://localhost:3000")) %>
-  <%= govuk_service_navigation(service_name: 'UK Trade Tariff Developer Portal', service_url: "#") do |nav| %>
-    <%= render 'layouts/navigation', header: nav %>
-  <% end %>
-
   <body class="govuk-template__body app-body-class">
+    <%= render "layouts/cookies_consent" %>
     <% if analytics_allowed? && TradeTariffDevHub.google_tag_manager_container_id.present? %>
       <%= render "shared/gtm", part: "body" %>
     <% end %>
-    <%= render "layouts/cookies_consent" %>
+    <%= govuk_header(homepage_url: ENV.fetch("GOVUK_APP_DOMAIN", "http://localhost:3000")) %>
+    <%= govuk_service_navigation(service_name: 'UK Trade Tariff Developer Portal', service_url: "#") do |nav| %>
+      <%= render 'layouts/navigation', header: nav %>
+    <% end %>
     <div class="govuk-width-container app-width-container">
     <script>document.body.className += ' js-enabled' + ('noModule' in HTMLScriptElement.prototype ? ' govuk-frontend-supported' : '');</script>
     <%= govuk_phase_banner(tag: { text: "Beta" }) do %>This is a new service, your
@@ -52,8 +51,6 @@
       <%= yield %>
     </main>
   </div>
-  </body>
-
   <%= govuk_footer(meta_items_title: "Helpful links", meta_items: {
     "API Documentation" => TradeTariffDevHub.documentation_url,
     "Feedback" =>  TradeTariffDevHub.feedback_url,
@@ -61,4 +58,5 @@
     "Cookies" => cookies_path,
     "Terms and conditions" => TradeTariffDevHub.terms_and_conditions_url,
   }) %>
+  </body>
 </html>


### PR DESCRIPTION
# Jira link

[OTTIMP-548](https://transformuk.atlassian.net/browse/OTTIMP-548)

The application layout placed govuk_header and govuk_service_navigation between </head> and <body>. Browsers treat that as invalid markup and insert those regions into the document before the explicit <body> content, so the cookie consent block appeared below the header.

This change moves header and service navigation inside <body> and orders markup as: cookie consent, optional GTM body snippet, then header and navigation, then the rest of the page. The footer is also moved inside <body> so the document structure is valid HTML.
