### PR TITLE
OTTIMP-538 Align footer links and valid HTML structure

### DIFF
--- a/app/lib/trade_tariff_dev_hub.rb
+++ b/app/lib/trade_tariff_dev_hub.rb
@@ -17,6 +17,13 @@ module TradeTariffDevHub
   ANALYTICS_COOKIE_PREFIXES = %w[_ga _gat _gid].freeze
 
   class << self
+    def enquiry_form_url
+      ENV.fetch(
+        "ENQUIRY_FORM_URL",
+        "https://www.trade-tariff.service.gov.uk/enquiry_form",
+      )
+    end
+
     def govuk_app_domain
       @govuk_app_domain ||= ENV.fetch(
         "GOVUK_APP_DOMAIN",
@@ -68,7 +75,7 @@ module TradeTariffDevHub
     def feedback_url
       ENV.fetch(
         "FEEDBACK_URL",
-        "http://localhost:3001/feedback",
+        "https://www.trade-tariff.service.gov.uk/feedback",
       )
     end
 

--- a/app/views/api_keys/index.html.erb
+++ b/app/views/api_keys/index.html.erb
@@ -39,5 +39,5 @@ end %>
 <%= govuk_button_link_to('Create new key', new_api_key_path, secondary: true) %>
 
 <h2 class="govuk-heading-m">If you need help</h2>
-<p class="govuk-body">Information and guidance in <%= govuk_link_to 'the FPO API (Opens in new tab)', 'https://docs.dev.trade-tariff.service.gov.uk/fpo.html', target: '_blank', rel: 'noreferrer noopener' %>.</p>
-<p class="govuk-body">If you have any further queries relating to the developer portal, <%= govuk_link_to 'use the enquiry form (Opens in new tab)', 'https://www.trade-tariff.service.gov.uk/enquiry_form', target: '_blank', rel: 'noreferrer noopener' %>.</p>
+<p class="govuk-body">Information and guidance in <%= govuk_link_to 'the FPO API (Opens in new tab)', 'https://docs.trade-tariff.service.gov.uk/fpo.html', target: '_blank', rel: 'noopener' %>.</p>
+<p class="govuk-body">If you have any further queries relating to the developer portal, <%= govuk_link_to 'use the enquiry form (Opens in new tab)', TradeTariffDevHub.enquiry_form_url, target: '_blank', rel: 'noopener' %>.</p>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -38,25 +38,42 @@
       <%= render 'layouts/navigation', header: nav %>
     <% end %>
     <div class="govuk-width-container app-width-container">
-    <script>document.body.className += ' js-enabled' + ('noModule' in HTMLScriptElement.prototype ? ' govuk-frontend-supported' : '');</script>
-    <%= govuk_phase_banner(tag: { text: "Beta" }) do %>This is a new service, your
-      <%= govuk_link_to("feedback (Opens in new tab)", ENV["FEEDBACK_URL"] || 'https://www.trade-tariff.service.gov.uk/feedback', target: "_blank", rel: "noreferrer noopener") %>
-      will help us improve it.
-    <% end %>
-    <% if content_for?(:back_link) %>
-      <%= yield :back_link %>
-    <% end %>
-    <main class="govuk-main-wrapper app-main-class" id="main-content">
-      <%= render 'flashes' %>
-      <%= yield %>
-    </main>
-  </div>
-  <%= govuk_footer(meta_items_title: "Helpful links", meta_items: {
-    "API Documentation" => TradeTariffDevHub.documentation_url,
-    "Feedback" =>  TradeTariffDevHub.feedback_url,
-    "Privacy policy" => privacy_path,
-    "Cookies" => cookies_path,
-    "Terms and conditions" => TradeTariffDevHub.terms_and_conditions_url,
-  }) %>
+      <script>document.body.className += ' js-enabled' + ('noModule' in HTMLScriptElement.prototype ? ' govuk-frontend-supported' : '');</script>
+      <%= govuk_phase_banner(tag: { text: "Beta" }) do %>This is a new service, your
+        <%= govuk_link_to("feedback (Opens in new tab)", ENV["FEEDBACK_URL"] || 'https://www.trade-tariff.service.gov.uk/feedback', target: "_blank", rel: "noopener") %>
+        will help us improve it.
+      <% end %>
+      <% if content_for?(:back_link) %>
+        <%= yield :back_link %>
+      <% end %>
+      <main class="govuk-main-wrapper app-main-class" id="main-content">
+        <%= render 'flashes' %>
+        <%= yield %>
+      </main>
+    </div>
+    <%= govuk_footer(meta_items: [
+      {
+        text: "API Documentation",
+        href: TradeTariffDevHub.documentation_url,
+        attr: { target: "_blank", rel: "noopener" },
+      },
+      {
+        text: "Enquiry form",
+        href: TradeTariffDevHub.enquiry_form_url,
+        attr: { target: "_blank", rel: "noopener" },
+      },
+      {
+        text: "Feedback",
+        href: TradeTariffDevHub.feedback_url,
+        attr: { target: "_blank", rel: "noopener" },
+      },
+      { text: "Privacy policy", href: privacy_path },
+      { text: "Cookies", href: cookies_path },
+      {
+        text: "Terms and conditions",
+        href: TradeTariffDevHub.terms_and_conditions_url,
+        attr: { target: "_blank", rel: "noopener" },
+      },
+    ]) %>
   </body>
 </html>

--- a/app/views/organisations/show.html.erb
+++ b/app/views/organisations/show.html.erb
@@ -127,6 +127,6 @@
   <div class="govuk-grid-column-two-thirds">
     <h2 class="govuk-heading-m">If you need help</h2>
     <p class="govuk-body">Information and guidance in <%= documentation_link %>.</p>
-    <p class="govuk-body">If you have any further queries relating to the developer portal, <%= govuk_link_to 'use the enquiry form (Opens in new tab)', 'https://www.trade-tariff.service.gov.uk/enquiry_form', target: '_blank', rel: 'noreferrer noopener' %>.</p>
+    <p class="govuk-body">If you have any further queries relating to the developer portal, <%= govuk_link_to 'use the enquiry form (Opens in new tab)', TradeTariffDevHub.enquiry_form_url, target: '_blank', rel: 'noopener' %>.</p>
   </div>
 </div>

--- a/app/views/trade_tariff_keys/index.html.erb
+++ b/app/views/trade_tariff_keys/index.html.erb
@@ -38,5 +38,5 @@ end %>
 <%= govuk_button_link_to('Create new Trade Tariff key', new_trade_tariff_key_path, secondary: true) %>
 
 <h2 class="govuk-heading-m">If you need help</h2>
-<p class="govuk-body">Information and guidance in <%= govuk_link_to 'the Trade Tariff API (Opens in new tab)', 'https://docs.dev.trade-tariff.service.gov.uk/the-trade-tariff-api.html', target: '_blank', rel: 'noreferrer noopener' %>.</p>
-<p class="govuk-body">If you have any further queries relating to the developer portal, <%= govuk_link_to 'use the enquiry form (Opens in new tab)', 'https://www.trade-tariff.service.gov.uk/enquiry_form', target: '_blank', rel: 'noreferrer noopener' %>.</p>
+<p class="govuk-body">Information and guidance in <%= govuk_link_to 'the Trade Tariff API (Opens in new tab)', 'https://docs.trade-tariff.service.gov.uk/the-trade-tariff-api.html', target: '_blank', rel: 'noopener' %>.</p>
+<p class="govuk-body">If you have any further queries relating to the developer portal, <%= govuk_link_to 'use the enquiry form (Opens in new tab)', TradeTariffDevHub.enquiry_form_url, target: '_blank', rel: 'noopener' %>.</p>


### PR DESCRIPTION
# Jira link

[OTTIMP-538](https://transformuk.atlassian.net/browse/OTTIMP-538)

## What?

Updates the application layout so the GOV.UK footer matches the agreed pattern: correct support link order (including Enquiry form), default visually hidden meta heading, and external links opening in a new tab where appropriate. Moves header, service navigation, and footer inside <body> for valid HTML. Introduces TradeTariffDevHub.enquiry_form_url (overridable via ENQUIRY_FORM_URL) and reuses it in copy that previously hard-coded the enquiry URL.
