### PR TITLE
Follow up Ruby 4.0.3 maintenance

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -36,11 +36,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1774273680,
-        "narHash": "sha256-a++tZ1RQsDb1I0NHrFwdGuRlR5TORvCEUksM459wKUA=",
+        "lastModified": 1778036283,
+        "narHash": "sha256-62EWg6lI0qyzm7oAx5cAnGkLutvJsRBe0KkEW2JDZCE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "fdc7b8f7b30fdbedec91b71ed82f36e1637483ed",
+        "rev": "ed67bc86e84e51d4a88e73c7fd36006dc876476f",
         "type": "github"
       },
       "original": {
@@ -61,11 +61,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1774420888,
-        "narHash": "sha256-LknAwF4BtEWuPbJTFXooydwwrZt9/WX6hEnhpAWb1Zc=",
+        "lastModified": 1777794641,
+        "narHash": "sha256-YynFFJm7k67pVgIuU4FJZu+qCL1+92g4lnRDHBFGsjw=",
         "owner": "bobvanderlinden",
         "repo": "nixpkgs-ruby",
-        "rev": "b15239544340b2e9c75664c3cc3b14a5b57cd8fd",
+        "rev": "21250b7913a4d439c77d3e7091bf246cb55544b5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## What
- Refresh `flake.lock` after rerunning `nix flake update`

## Why
- complete the Ruby 4.0.3 maintenance follow-up after merged PR #174

## Verification
- checked current Ruby target files on the default branch
- reran `nix flake update`
- confirmed the resulting diff is limited to: flake.lock
