### PR TITLE
Fix CSP violation report endpoint throwing exceptions

### DIFF
--- a/app/controllers/csp_reports_controller.rb
+++ b/app/controllers/csp_reports_controller.rb
@@ -1,10 +1,7 @@
 class CspReportsController < ActionController::API
   def create
-    payload = request.raw_post
+    Rails.logger.warn("CSP Violation: #{request.raw_post}")
 
-    Rails.logger.warn("CSP Violation: #{payload}")
-    NewRelic::Agent.notice_error("CSP Violation: #{payload}")
-
-    head :ok
+    head :no_content
   end
 end

--- a/spec/requests/csp_reports_spec.rb
+++ b/spec/requests/csp_reports_spec.rb
@@ -10,11 +10,9 @@ RSpec.describe "CspReports", type: :request do
   describe "POST /csp-violation-report" do
     let(:payload) { '{"csp-report":{"document-uri":"https://example.com"}}' }
 
-    before do
-      allow(NewRelic::Agent).to receive(:notice_error)
-    end
+    it "accepts a CSP report without a CSRF token and logs it" do
+      allow(Rails.logger).to receive(:warn)
 
-    it "accepts a CSP report without a CSRF token", :aggregate_failures do
       post "/csp-violation-report",
            params: payload,
            headers: {
@@ -22,8 +20,8 @@ RSpec.describe "CspReports", type: :request do
              "ACCEPT" => "application/json",
            }
 
-      expect(response).to have_http_status(:ok)
-      expect(NewRelic::Agent).to have_received(:notice_error).with("CSP Violation: #{payload}")
+      expect(response).to have_http_status(:no_content)
+      expect(Rails.logger).to have_received(:warn).with("CSP Violation: #{payload}")
     end
   end
 end

--- a/spec/requests/csp_reports_spec.rb
+++ b/spec/requests/csp_reports_spec.rb
@@ -10,7 +10,18 @@ RSpec.describe "CspReports", type: :request do
   describe "POST /csp-violation-report" do
     let(:payload) { '{"csp-report":{"document-uri":"https://example.com"}}' }
 
-    it "accepts a CSP report without a CSRF token and logs it" do
+    it "accepts a CSP report without a CSRF token" do
+      post "/csp-violation-report",
+           params: payload,
+           headers: {
+             "CONTENT_TYPE" => "application/csp-report",
+             "ACCEPT" => "application/json",
+           }
+
+      expect(response).to have_http_status(:no_content)
+    end
+
+    it "logs the CSP violation" do
       allow(Rails.logger).to receive(:warn)
 
       post "/csp-violation-report",
@@ -20,7 +31,6 @@ RSpec.describe "CspReports", type: :request do
              "ACCEPT" => "application/json",
            }
 
-      expect(response).to have_http_status(:no_content)
       expect(Rails.logger).to have_received(:warn).with("CSP Violation: #{payload}")
     end
   end


### PR DESCRIPTION
## Summary

- `NewRelic::Agent.notice_error` expects an `Exception` object — passing a plain string causes it to raise or behave incorrectly depending on gem version
- CSP violations are browser-generated informational reports, not application errors; they should not appear in New Relic error tracking
- Returns `204 No Content` instead of `200 OK`, which is the correct HTTP semantics for a report endpoint