### PR TITLE
BAU: Fix Terraform docs linting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,8 @@ jobs:
           terraform_version: ${{ env.TERRAFORM_VERSION }}
       - uses: trade-tariff/trade-tariff-tools/.github/actions/setup-tflint@main
       - uses: trade-tariff/trade-tariff-tools/.github/actions/setup-terraform-docs@main
+        with:
+          terraform_docs_version: 0.22.0
       - uses: trade-tariff/trade-tariff-tools/.github/actions/setup-ssh@main
         with:
           ssh-key: ${{ secrets.PRIVATE_SSH_KEY }}

--- a/flake.nix
+++ b/flake.nix
@@ -82,6 +82,7 @@
             lint
             postgresql
             postgresql-start
+            pkgs.terraform-docs
             ruby
             update-providers
           ];


### PR DESCRIPTION
### Jira link

BAU

### What?

- [x] Pin the CI terraform-docs setup action to `0.22.0`.
- [x] Add `terraform-docs` to the local Nix development shell.

### Why?

Matches the Terraform docs linting fix from trade-tariff-backend#3143 so local and CI runs use the same terraform-docs version.


### Risk

**Risk level:** 🟢

**Reason for rating:**
Terraform docs linting and local/CI tooling only. There is no application runtime or Terraform resource change; the main risk is CI surfacing generated README formatting differences.
