### PR TITLE
BAU: Update pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 ---
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.103.0
+    rev: v1.105.0
     hooks:
       - id: terraform_fmt
       - id: terraform_validate
@@ -22,15 +22,14 @@ repos:
         files: '.env.development|.env.test'
 
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.46.0
+    rev: v0.48.0
     hooks:
-      - id: markdownlint-docker
+      - id: markdownlint-fix
         args:
           - "--disable"
           - "MD013"
           - "--ignore"
           - terraform
-          - "--fix"
 
   - repo: https://github.com/mattlqx/pre-commit-ruby
     rev: v1.3.6
@@ -39,7 +38,7 @@ repos:
         args: ["--autocorrect"]
 
   - repo: https://github.com/rhysd/actionlint.git
-    rev: v1.7.8
+    rev: v1.7.12
     hooks:
       - id: actionlint-docker
 


### PR DESCRIPTION
### Jira link

BAU

### What?

- [x] Run `pre-commit autoupdate` for stale hook refs where available.
- [x] Switch markdown linting from the Docker image hook to the Node `markdownlint-fix` hook.

### Why?

The `markdownlint-docker` hook pulls `ghcr.io/igorshubovych/markdownlint-cli:v0.48.0` in CI. Using the non-Docker hook avoids the GHCR image pull path while preserving markdown auto-fix behaviour.

### Validation

- `pre-commit validate-config`
- `pre-commit run markdownlint-fix --all-files`
- `git diff --check`


### Risk

**Risk level:** 🟢

**Reason for rating:**
Pre-commit hook configuration only. There is no application runtime or infrastructure behaviour change; the main risk is CI surfacing markdown or hook-version differences earlier than before.
