### PR TITLE
Enable key deletion in all environments

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -7,7 +7,6 @@
 # Set to GTM-KPM7NRDG when testing analytics integration.
 # TRADE_TARIFF_USAGE_PLAN_ID=<usage plan id from API Gateway - see docs/TRADE_TARIFF_KEYS_SETUP.md>
 AWS_DEFAULT_REGION=eu-west-2
-DELETION_ENABLED=true
 DEV_BYPASS_ADMIN_PASSWORD=admin123
 DEV_BYPASS_AUTH=true
 DEV_BYPASS_USER_PASSWORD=tariff123

--- a/.env.test
+++ b/.env.test
@@ -1,6 +1,5 @@
 APPLICATION_SUPPORT_EMAIL="foo@bar.com"
 AWS_DEFAULT_REGION=eu-west-2
-DELETION_ENABLED=true
 ENCRYPTION_KEY=+WxrxtmkNdODyHrrwh1K2msWts1HVCCf7B98Q0odcUs=
 FEEDBACK_URL='https://dev.trade-tariff.service.gov.uk/feedback'
 GOVUK_APP_DOMAIN='*'

--- a/app/controllers/api_keys_controller.rb
+++ b/app/controllers/api_keys_controller.rb
@@ -16,10 +16,8 @@ class ApiKeysController < AuthenticatedController
   def update
     if @api_key.enabled
       render "revoke"
-    elsif deletion_enabled?
-      render "delete"
     else
-      raise NotImplementedError, "API key deletion is not implemented"
+      render "delete"
     end
   end
 
@@ -74,6 +72,4 @@ private
   def api_key_params
     params.require(:api_key).permit(:description)
   end
-
-  delegate :deletion_enabled?, to: TradeTariffDevHub
 end

--- a/app/lib/trade_tariff_dev_hub.rb
+++ b/app/lib/trade_tariff_dev_hub.rb
@@ -31,10 +31,6 @@ module TradeTariffDevHub
       )
     end
 
-    def deletion_enabled?
-      ENV.fetch("DELETION_ENABLED", "false") == "true"
-    end
-
     def role_request_enabled?
       # Allow explicit override via environment variable
       return ENV["FEATURE_FLAG_ROLE_REQUEST"] == "true" if ENV.key?("FEATURE_FLAG_ROLE_REQUEST")

--- a/app/views/api_keys/index.html.erb
+++ b/app/views/api_keys/index.html.erb
@@ -26,9 +26,7 @@
           end
         else
           row.with_cell do
-            if TradeTariffDevHub.deletion_enabled?
-              link_to 'Delete', delete_api_key_path(api_key.id), class: 'govuk-link'
-            end
+            link_to 'Delete', delete_api_key_path(api_key.id), class: 'govuk-link'
           end
         end
       end

--- a/app/views/shared/_api_key_actions.html.erb
+++ b/app/views/shared/_api_key_actions.html.erb
@@ -1,7 +1,5 @@
 <% if key.enabled? %>
   <%= link_to 'Revoke', revoke_api_key_path(key), method: :patch, class: 'govuk-link', data: { confirm: 'Are you sure you want to revoke this API key?' } %>
-<% elsif TradeTariffDevHub.deletion_enabled? %>
-  <%= link_to 'Delete', delete_api_key_path(key), class: 'govuk-link govuk-link--warning', data: { confirm: 'Are you sure you want to permanently delete this API key? This action cannot be undone.' } %>
 <% else %>
-  <span class="govuk-hint govuk-!-margin-0">No actions available</span>
+  <%= link_to 'Delete', delete_api_key_path(key), class: 'govuk-link govuk-link--warning', data: { confirm: 'Are you sure you want to permanently delete this API key? This action cannot be undone.' } %>
 <% end %>

--- a/app/views/shared/_trade_tariff_key_actions.html.erb
+++ b/app/views/shared/_trade_tariff_key_actions.html.erb
@@ -1,7 +1,5 @@
 <% if key.active? %>
   <%= link_to 'Revoke', revoke_trade_tariff_key_path(key), method: :patch, class: 'govuk-link', data: { confirm: 'Are you sure you want to revoke this Trade Tariff key? This action cannot be undone.' } %>
-<% elsif TradeTariffDevHub.deletion_enabled? %>
-  <%= link_to 'Delete', delete_trade_tariff_key_path(key), method: :delete, class: 'govuk-link govuk-link--warning', data: { confirm: 'Are you sure you want to permanently delete this Trade Tariff key? This action cannot be undone.' } %>
 <% else %>
-  <span class="govuk-hint govuk-!-margin-0">No actions available</span>
+  <%= link_to 'Delete', delete_trade_tariff_key_path(key), method: :delete, class: 'govuk-link govuk-link--warning', data: { confirm: 'Are you sure you want to permanently delete this Trade Tariff key? This action cannot be undone.' } %>
 <% end %>

--- a/app/views/trade_tariff_keys/index.html.erb
+++ b/app/views/trade_tariff_keys/index.html.erb
@@ -26,7 +26,7 @@
         row.with_cell do
           if trade_tariff_key.active?
             link_to 'Revoke', revoke_trade_tariff_key_path(trade_tariff_key.id), class: 'govuk-link'
-          elsif TradeTariffDevHub.deletion_enabled?
+          else
             link_to 'Delete', delete_trade_tariff_key_path(trade_tariff_key.id), class: 'govuk-link'
           end
         end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,10 +36,8 @@ Rails.application.routes.draw do
       get :revoke, to: "api_keys#update", as: :revoke
       patch :revoke
 
-      if TradeTariffDevHub.deletion_enabled?
-        get :delete, to: "api_keys#update", as: :delete
-        delete :delete
-      end
+      get :delete, to: "api_keys#update", as: :delete
+      delete :delete
     end
   end
 
@@ -48,10 +46,8 @@ Rails.application.routes.draw do
       get :revoke, to: 'trade_tariff_keys#confirm_action', as: :revoke
       patch :revoke
 
-      if TradeTariffDevHub.deletion_enabled?
-        get :delete, to: 'trade_tariff_keys#confirm_action', as: :delete
-        delete :delete
-      end
+      get :delete, to: 'trade_tariff_keys#confirm_action', as: :delete
+      delete :delete
     end
   end
 


### PR DESCRIPTION
# Jira link

[OTTIMP-537](https://transformuk.atlassian.net/browse/OTTIMP-537)

## What?

Remove the DELETION_ENABLED flag so revoked FPO and Trade Tariff keys can always be deleted, including in production. Delete routes and UI are no longer conditional on that env var.