### PR TITLE
BAU: Enable admins to remove users from other orgs

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,30 +1,41 @@
 class UsersController < AuthenticatedController
+  include RecordOwnershipAuthorization
+
   def remove; end
 
   def destroy
+    redirect_path = redirect_path_after_action
+
     if user.destroy
-      redirect_to organisation_path(organisation.id), notice: "User #{user.email_address} has been removed from the organisation."
+      redirect_to redirect_path, notice: "User #{user.email_address} has been removed from the organisation."
     else
-      redirect_to organisation_path(organisation.id), alert: "There was a problem removing the user #{user.email_address} from the organisation."
+      redirect_to redirect_path, alert: "There was a problem removing the user #{user.email_address} from the organisation."
     end
   end
 
 private
 
   def allowed?
-    user != current_user &&
-      current_user.organisation.users.include?(user)
+    return false if user.nil? || user == current_user
+
+    current_user.organisation.users.include?(user) || current_user.admin?
   end
 
   def disallowed_redirect!
+    redirect_path = redirect_path_after_action
+
     if user == current_user
-      redirect_to organisation_path(organisation.id), alert: "You cannot delete your own user account"
+      redirect_to redirect_path, alert: "You cannot delete your own user account"
     else
-      redirect_to organisation_path(organisation.id), alert: "You can only delete users from your own organisation."
+      redirect_to redirect_path, alert: "You can only delete users from your own organisation."
     end
   end
 
+  def redirect_path_after_action
+    redirect_path_for_owned_record(user, default_path: organisation_path(organisation.id))
+  end
+
   def user
-    @user ||= User.find_by(id: params[:id])
+    @user ||= find_owned_record(User)
   end
 end

--- a/app/helpers/back_link_helper.rb
+++ b/app/helpers/back_link_helper.rb
@@ -7,6 +7,10 @@ module BackLinkHelper
     back_link_path_for_organisation_record(api_key, fallback_path: api_keys_path)
   end
 
+  def back_link_path_for_user(user)
+    back_link_path_for_organisation_record(user, fallback_path: organisation_path(organisation))
+  end
+
 private
 
   def back_link_path_for_organisation_record(record, fallback_path:)

--- a/app/views/admin/organisations/show.html.erb
+++ b/app/views/admin/organisations/show.html.erb
@@ -76,6 +76,7 @@
           head.with_row do |row|
             row.with_cell(text: 'Email address')
             row.with_cell(text: 'Created')
+            row.with_cell(text: 'Actions')
           end
         end
         table.with_body do |body|
@@ -83,6 +84,13 @@
             body.with_row do |row|
               row.with_cell(header: true, text: user.email_address)
               row.with_cell(text: user.created_at.strftime('%d %b %Y'))
+              row.with_cell do
+                if user == current_user
+                  'You'
+                else
+                  govuk_link_to('Remove', remove_user_path(user))
+                end
+              end
             end
           end
         end

--- a/app/views/users/remove.html.erb
+++ b/app/views/users/remove.html.erb
@@ -1,3 +1,4 @@
+<% content_for :back_link do %><%= govuk_back_link(href: back_link_path_for_user(@user)) %><% end %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l">Remove a user from an organisation</h1>
@@ -16,4 +17,4 @@
     end
 %>
 
-<%= govuk_button_group_form_to 'Remove', user_path(@user), method: :delete, cancel_path: organisation_path(current_user.organisation), warning: true %>
+<%= govuk_button_group_form_to 'Remove', user_path(@user), method: :delete, cancel_path: back_link_path_for_user(@user), warning: true %>

--- a/spec/requests/admin/organisations_spec.rb
+++ b/spec/requests/admin/organisations_spec.rb
@@ -52,5 +52,26 @@ RSpec.describe "Admin::Organisations", type: :request do
       expect(response.body).to include('class="govuk-back-link"')
       expect(response.body).to include("href=\"#{admin_organisations_path}\"")
     end
+
+    it "renders member actions with remove links for other users", :aggregate_failures do
+      other_user = create(:user, email_address: "member@example.com", organisation: other_organisation)
+
+      get admin_organisation_path(other_organisation)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Remove")
+      expect(response.body).to include(remove_user_path(other_user))
+    end
+
+    it "shows You for the current user on their own admin organisation page", :aggregate_failures do
+      fellow_admin = create(:user, email_address: "fellow@example.com", organisation: admin_organisation)
+
+      get admin_organisation_path(admin_organisation)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("You")
+      expect(response.body).to include(remove_user_path(fellow_admin))
+      expect(response.body).not_to include(remove_user_path(current_user))
+    end
   end
 end

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -35,14 +35,31 @@ RSpec.describe "Users", type: :request do
         expect(response.body).to include("You can only delete users from your own organisation.")
       end
     end
+
+    context "when user is an admin accessing another organisation's user" do
+      let(:admin_organisation) { create(:organisation, :admin) }
+      let(:current_user) { create(:user, organisation: admin_organisation) }
+      let(:other_organisation) { create(:organisation) }
+      let!(:other_user) { create(:user, email_address: "foo@baz.com", organisation: other_organisation) }
+      let(:params) { { id: other_user.id } }
+
+      it "allows admin to access the remove confirmation page", :aggregate_failures do
+        get remove_user_path(other_user), params: params
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include(other_user.email_address)
+        expect(response.body).to include("Remove a user from an organisation")
+        expect(response.body).to include("href=\"#{admin_organisation_path(other_organisation.id)}\"")
+      end
+    end
   end
 
   describe "DELETE /users/:id" do
     let(:other_user) { create(:user, email_address: "foo@baz.com", organisation: current_user.organisation) }
     let(:params) { { id: other_user.id } }
-    let(:organisation) { current_user.organisation }
 
     it "deletes the user and redirects to the organisation page with a notice", :aggregate_failures do
+      organisation = current_user.organisation
+
       delete user_path(other_user), params: params
       expect(response).to redirect_to(organisation_path(organisation.id))
       follow_redirect!
@@ -52,6 +69,7 @@ RSpec.describe "Users", type: :request do
 
     context "when trying to delete oneself" do
       let(:params) { { id: current_user.id } }
+      let(:organisation) { current_user.organisation }
 
       it "redirects to the organisation page with an alert and does not delete the user", :aggregate_failures do
         delete user_path(current_user), params: params
@@ -74,6 +92,34 @@ RSpec.describe "Users", type: :request do
         follow_redirect!
         expect(response.body).to include("You can only delete users from your own organisation.")
         expect(User.where(id: other_user.id)).to exist
+      end
+    end
+
+    context "when user is an admin deleting another organisation's user" do
+      let(:current_user) { create(:user, organisation: create(:organisation, :admin)) }
+      let(:other_organisation) { create(:organisation) }
+      let!(:other_user) { create(:user, email_address: "foo@baz.com", organisation: other_organisation) }
+
+      it "deletes the user and redirects to admin organisation page", :aggregate_failures do
+        delete user_path(other_user), params: params
+        expect(response).to redirect_to(admin_organisation_path(other_organisation.id))
+        follow_redirect!
+        expect(response.body).to include("User #{other_user.email_address} has been removed from the organisation.")
+        expect(User.where(id: other_user.id)).to be_empty
+      end
+    end
+
+    context "when user is an admin trying to delete themselves" do
+      let(:admin_organisation) { create(:organisation, :admin) }
+      let(:current_user) { create(:user, organisation: admin_organisation) }
+      let(:params) { { id: current_user.id } }
+
+      it "redirects with an alert and does not delete the user", :aggregate_failures do
+        delete user_path(current_user), params: params
+        expect(response).to redirect_to(organisation_path(admin_organisation.id))
+        follow_redirect!
+        expect(response.body).to include("You cannot delete your own user account")
+        expect(User.where(id: current_user.id)).to exist
       end
     end
   end


### PR DESCRIPTION


## What?

Allows admin users to remove members from any organisation via the admin org page, while keeping existing restrictions for regular users (own org only, cannot remove themselves). Redirects and back links return admins to the organisation they were viewing.
