### PR TITLE
Align terms across platform

### DIFF
--- a/app/views/api_keys/index.html.erb
+++ b/app/views/api_keys/index.html.erb
@@ -37,5 +37,5 @@ end %>
 <%= govuk_button_link_to('Create new key', new_api_key_path, secondary: true) %>
 
 <h2 class="govuk-heading-m">If you need help</h2>
-<p class="govuk-body">Information and guidance in <%= govuk_link_to 'the FPO API (Opens in new tab)', 'https://docs.trade-tariff.service.gov.uk/fpo.html', target: '_blank', rel: 'noopener' %>.</p>
-<p class="govuk-body">If you have any further queries relating to the developer portal, <%= govuk_link_to 'use the enquiry form (Opens in new tab)', TradeTariffDevHub.enquiry_form_url, target: '_blank', rel: 'noopener' %>.</p>
+<p class="govuk-body">Information and guidance in <%= govuk_link_to 'the FPO API (opens in new tab)', 'https://docs.trade-tariff.service.gov.uk/fpo.html', target: '_blank', rel: 'noopener' %>.</p>
+<p class="govuk-body">If you have any further queries relating to the developer portal, <%= govuk_link_to 'use the enquiry form (opens in new tab)', TradeTariffDevHub.enquiry_form_url, target: '_blank', rel: 'noopener' %>.</p>

--- a/app/views/homepage/index.html.erb
+++ b/app/views/homepage/index.html.erb
@@ -1,9 +1,9 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l">UK Trade Tariff Developer Portal</h1>
+    <h1 class="govuk-heading-l">Trade Tariff Developer Portal</h1>
 
     <p class="govuk-body">
-      Welcome to the official GOV.UK Developer Portal for HMRC Trade Tariff APIs.
+      Welcome to the official Developer Portal for HMRC Trade Tariff APIs.
     </p>
 
     <h3 class="govuk-heading-m">What you can do</h3>

--- a/app/views/layouts/_navigation.html.erb
+++ b/app/views/layouts/_navigation.html.erb
@@ -3,19 +3,19 @@
   <% is_admin = current_user&.organisation&.admin? %>
   <% viewed_org = organisation %>
 
-  <%= header.with_navigation_item(text: "Your Organisation Account", href: organisation_path(current_user.organisation)) %>
+  <%= header.with_navigation_item(text: "Your organisation", href: organisation_path(current_user.organisation)) %>
 
   <% if is_admin %>
-    <%= header.with_navigation_item(text: "All Organisations", href: admin_organisations_path, active: current_page?(admin_organisations_path)) %>
+    <%= header.with_navigation_item(text: "All organisations", href: admin_organisations_path, active: current_page?(admin_organisations_path)) %>
     <% if TradeTariffDevHub.role_request_enabled? %>
       <% pending_count = pending_role_requests_count %>
       <% if pending_count > 0 %>
         <% access_requests_text = capture do %>
-          Access Requests <span class="govuk-tag govuk-tag--blue" style="margin-left: 0.5em; font-size: 0.875em; vertical-align: middle;"><%= pending_count %></span>
+          Access requests <span class="govuk-tag govuk-tag--blue" style="margin-left: 0.5em; font-size: 0.875em; vertical-align: middle;"><%= pending_count %></span>
         <% end %>
         <%= header.with_navigation_item(text: access_requests_text.html_safe, href: admin_role_requests_path, active: current_page?(admin_role_requests_path)) %>
       <% else %>
-        <%= header.with_navigation_item(text: "Access Requests", href: admin_role_requests_path, active: current_page?(admin_role_requests_path)) %>
+        <%= header.with_navigation_item(text: "Access requests", href: admin_role_requests_path, active: current_page?(admin_role_requests_path)) %>
       <% end %>
     <% end %>
   <% end %>
@@ -23,13 +23,13 @@
   <%# Service role navigation (visible to admins AND users with those roles) %>
   <%# Use viewed_org for role checks (if viewing as another org, check that org's roles) %>
   <% if is_admin || viewed_org&.has_role?("fpo:full") %>
-    <%= header.with_navigation_item(text: "FPO Keys", href: api_keys_path, active: current_page?(api_keys_path)) %>
+    <%= header.with_navigation_item(text: "FPO keys", href: api_keys_path, active: current_page?(api_keys_path)) %>
   <% end %>
 
   <% if is_admin || viewed_org&.has_role?("trade_tariff:full") %>
-    <%= header.with_navigation_item(text: "Trade Tariff Keys", href: trade_tariff_keys_path, active: current_page?(trade_tariff_keys_path)) %>
+    <%= header.with_navigation_item(text: "Trade Tariff keys", href: trade_tariff_keys_path, active: current_page?(trade_tariff_keys_path)) %>
   <% end %>
 
   <%# Common navigation (everyone sees these) %>
-  <%= header.with_navigation_item(text: "Sign Out", href: logout_path, active: false) %>
+  <%= header.with_navigation_item(text: "Sign out", href: logout_path, active: false) %>
 <% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -4,7 +4,7 @@
     <% if analytics_allowed? && TradeTariffDevHub.google_tag_manager_container_id.present? %>
       <%= render "shared/gtm", part: "head" %>
     <% end %>
-    <title><%= content_for(:title) || "UK Trade Tariff Developer Portal" %></title>
+    <title><%= content_for(:title) || "Trade Tariff Developer Portal" %></title>
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="mobile-web-app-capable" content="yes">
@@ -34,13 +34,13 @@
       <%= render "shared/gtm", part: "body" %>
     <% end %>
     <%= govuk_header(homepage_url: ENV.fetch("GOVUK_APP_DOMAIN", "http://localhost:3000")) %>
-    <%= govuk_service_navigation(service_name: 'UK Trade Tariff Developer Portal', service_url: "#") do |nav| %>
+    <%= govuk_service_navigation(service_name: 'Trade Tariff Developer Portal', service_url: "#") do |nav| %>
       <%= render 'layouts/navigation', header: nav %>
     <% end %>
     <div class="govuk-width-container app-width-container">
       <script>document.body.className += ' js-enabled' + ('noModule' in HTMLScriptElement.prototype ? ' govuk-frontend-supported' : '');</script>
       <%= govuk_phase_banner(tag: { text: "Beta" }) do %>This is a new service, your
-        <%= govuk_link_to("feedback (Opens in new tab)", ENV["FEEDBACK_URL"] || 'https://www.trade-tariff.service.gov.uk/feedback', target: "_blank", rel: "noopener") %>
+        <%= govuk_link_to("feedback (opens in new tab)", ENV["FEEDBACK_URL"] || 'https://www.trade-tariff.service.gov.uk/feedback', target: "_blank", rel: "noopener") %>
         will help us improve it.
       <% end %>
       <% if content_for?(:back_link) %>
@@ -53,7 +53,7 @@
     </div>
     <%= govuk_footer(meta_items: [
       {
-        text: "API Documentation",
+        text: "API documentation",
         href: TradeTariffDevHub.documentation_url,
         attr: { target: "_blank", rel: "noopener" },
       },

--- a/app/views/organisations/show.html.erb
+++ b/app/views/organisations/show.html.erb
@@ -2,9 +2,9 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l">Your Organisation Account</h1>
+    <h1 class="govuk-heading-l">Your organisation</h1>
     <% if is_admin %>
-      <p class="govuk-body">Manage your organisational details and API keys, as well as grant access requests and manage your team members. From this page you can invite new team members to join the UK Trade Tariff Developer Portal, or remove existing members.</p>
+      <p class="govuk-body">Manage your organisational details and API keys, as well as grant access requests and manage your team members. From this page you can invite new team members to join the Developer Portal, or remove existing members.</p>
     <% else %>
       <p class="govuk-body">Manage your organisational details and request access to roles as well as invite new and remove existing members.</p>
     <% end %>
@@ -127,6 +127,6 @@
   <div class="govuk-grid-column-two-thirds">
     <h2 class="govuk-heading-m">If you need help</h2>
     <p class="govuk-body">Information and guidance in <%= documentation_link %>.</p>
-    <p class="govuk-body">If you have any further queries relating to the developer portal, <%= govuk_link_to 'use the enquiry form (Opens in new tab)', TradeTariffDevHub.enquiry_form_url, target: '_blank', rel: 'noopener' %>.</p>
+    <p class="govuk-body">If you have any further queries relating to the developer portal, <%= govuk_link_to 'use the enquiry form (opens in new tab)', TradeTariffDevHub.enquiry_form_url, target: '_blank', rel: 'noopener' %>.</p>
   </div>
 </div>

--- a/app/views/pages/cookies.html.erb
+++ b/app/views/pages/cookies.html.erb
@@ -1,4 +1,4 @@
-<h1 class="govuk-heading-xl">Cookies on the UK Trade Tariff Developer Portal</h1>
+<h1 class="govuk-heading-xl">Cookies on the Trade Tariff Developer Portal</h1>
 <p class="govuk-body">Cookies are files saved on your phone, tablet or computer when you visit a website. We use cookies to store information about how you use this website, such as the pages you visit.</p>
 
 <p class="govuk-body">

--- a/app/views/pages/privacy.html.erb
+++ b/app/views/pages/privacy.html.erb
@@ -1,7 +1,7 @@
 <h1 class="govuk-heading-xl">Privacy notice</h1>
 
 <p class="govuk-body">
-  Commodity Code Identification Tool Developer Portal (the ‘service’) is provided by HM Revenue and Customs (HMRC). HMRC will be referred to as ‘we’ or ‘us’ throughout this notice.
+  Trade Tariff Developer Portal (the ‘service’) is provided by HM Revenue and Customs (HMRC). HMRC will be referred to as ‘we’ or ‘us’ throughout this notice.
 </p>
 
 <p class="govuk-body">We are committed to protecting the privacy and security of your personal information.</p>
@@ -52,7 +52,7 @@
 
 <p class="govuk-body">In order for the use of personal data to be lawful, we need to meet one (or more) conditions in the data protection legislation, as set out in Article 6(1) of the General Data Protection Regulation (GDPR).</p>
 
-<p class="govuk-body">For the purpose of providing the Commodity Code Identification Tool Developer Portal, the relevant condition that we are meeting is ‘public task’ as specified under Article 6 (1)(e) of the GDPR.</p>
+<p class="govuk-body">For the purpose of providing the Trade Tariff Developer Portal, the relevant condition that we are meeting is ‘public task’ as specified under Article 6 (1)(e) of the GDPR.</p>
 
 <h2 class="govuk-heading-m">Who we share your data with</h2>
 
@@ -131,15 +131,15 @@ at: <%= govuk_link_to "advice.dpa@hmrc.gov.uk", "mailto:advice.dpa@hmrc.gov.uk" 
 </p>
 
 <p class="govuk-body">
-  You can read more about how the <abbr title="Data Protection Officer">DPO</abbr> handles your personal information in our <%= govuk_link_to "Office of the Data Protection Officer Privacy Notice (Opens in new tab)", "https://www.gov.uk/government/publications/hmrc-office-of-the-data-protection-officer-privacy-notice", target: "_blank", rel: "noreferrer noopener" %>
+  You can read more about how the <abbr title="Data Protection Officer">DPO</abbr> handles your personal information in our <%= govuk_link_to "Office of the Data Protection Officer Privacy Notice (opens in new tab)", "https://www.gov.uk/government/publications/hmrc-office-of-the-data-protection-officer-privacy-notice", target: "_blank", rel: "noreferrer noopener" %>
 </p>
 
 <p class="govuk-body">
-  If you want to request a copy of your personal data follow HMRC’s <%= govuk_link_to "subject access request guidance (Opens in new tab)", "https://www.gov.uk/guidance/hmrc-subject-access-request", target: "_blank", rel: "noreferrer noopener" %>.
+  If you want to request a copy of your personal data follow HMRC’s <%= govuk_link_to "subject access request guidance (opens in new tab)", "https://www.gov.uk/guidance/hmrc-subject-access-request", target: "_blank", rel: "noreferrer noopener" %>.
 </p>
 
 <p class="govuk-body">
-  You should follow the existing complaints process if you want to <%= govuk_link_to "complain about HMRC (Opens in new tab)", "https://www.gov.uk/government/organisations/hm-revenue-customs/contact/complain-about-hmrc", target: "_blank", rel: "noreferrer noopener" %>
+  You should follow the existing complaints process if you want to <%= govuk_link_to "complain about HMRC (opens in new tab)", "https://www.gov.uk/government/organisations/hm-revenue-customs/contact/complain-about-hmrc", target: "_blank", rel: "noreferrer noopener" %>
 </p>
 
 <p class="govuk-body">

--- a/app/views/trade_tariff_keys/index.html.erb
+++ b/app/views/trade_tariff_keys/index.html.erb
@@ -38,5 +38,5 @@ end %>
 <%= govuk_button_link_to('Create new Trade Tariff key', new_trade_tariff_key_path, secondary: true) %>
 
 <h2 class="govuk-heading-m">If you need help</h2>
-<p class="govuk-body">Information and guidance in <%= govuk_link_to 'the Trade Tariff API (Opens in new tab)', 'https://docs.trade-tariff.service.gov.uk/the-trade-tariff-api.html', target: '_blank', rel: 'noopener' %>.</p>
-<p class="govuk-body">If you have any further queries relating to the developer portal, <%= govuk_link_to 'use the enquiry form (Opens in new tab)', TradeTariffDevHub.enquiry_form_url, target: '_blank', rel: 'noopener' %>.</p>
+<p class="govuk-body">Information and guidance in <%= govuk_link_to 'the Trade Tariff API (opens in new tab)', 'https://docs.trade-tariff.service.gov.uk/the-trade-tariff-api.html', target: '_blank', rel: 'noopener' %>.</p>
+<p class="govuk-body">If you have any further queries relating to the developer portal, <%= govuk_link_to 'use the enquiry form (opens in new tab)', TradeTariffDevHub.enquiry_form_url, target: '_blank', rel: 'noopener' %>.</p>

--- a/spec/requests/organisations_spec.rb
+++ b/spec/requests/organisations_spec.rb
@@ -13,6 +13,8 @@ RSpec.describe "Organisations", type: :request do
       get organisation_path(current_user.organisation)
       expect(response).to have_http_status(:ok)
       expect(response.body).to include(current_user.organisation.organisation_name)
+      expect(response.body).to include("Your organisation")
+      expect(response.body).not_to include("Your Organisation Account")
     end
 
     context "when accessing another organisation as a non-admin user" do

--- a/spec/requests/pages_spec.rb
+++ b/spec/requests/pages_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "Pages", type: :request do
       get "/cookies"
 
       expect(response).to have_http_status(:ok)
-      expect(response.body).to include("Cookies on the UK Trade Tariff Developer Portal")
+      expect(response.body).to include("Cookies on the Trade Tariff Developer Portal")
       expect(response.body).to include("Cookies that measure website use")
     end
   end


### PR DESCRIPTION
# Jira link

https://transformuk.atlassian.net/browse/OTTIMP-566

### What?
I have added/removed/altered:

- Renamed nav label and org page H1 to "Your organisation"
- Renamed user-facing copy to "Trade Tariff Developer Portal" (OTTIMP-458)
- Updated footer label to "API documentation"
- Standardised "(opens in new tab)" microcopy to lowercase

### Why?
I am doing this because:

- Align Developer Portal UI with the wider OTT ecosystem
- Prevent nav wrapping and apply agreed site naming
- Match microcopy and footer patterns used on the API docs site
