### PR TITLE
BAU: Align GOV.UK button pairs

### DIFF
--- a/app/helpers/govuk_helper.rb
+++ b/app/helpers/govuk_helper.rb
@@ -12,4 +12,18 @@ module GovukHelper
       ], "\n"
     end
   end
+
+  def govuk_button_group_form_to(button_text, path, method:, cancel_path:, **button_options)
+    form_tag(path, method:) do
+      content_tag(:div, class: "govuk-button-group") do
+        safe_join(
+          [
+            button_tag(button_text, class: govuk_button_classes(**button_options), data: { module: "govuk-button" }),
+            govuk_link_to("Cancel", cancel_path),
+          ],
+          "\n",
+        )
+      end
+    end
+  end
 end

--- a/app/views/api_keys/delete.html.erb
+++ b/app/views/api_keys/delete.html.erb
@@ -27,7 +27,4 @@
   end
 %>
 
-<div class="govuk-button-group">
-  <%= govuk_button_to 'Delete', delete_api_key_path, method: :delete, class: 'govuk-button govuk-button--warning' %>
-  <%= govuk_link_to 'Cancel', api_keys_path, class: 'govuk-link' %>
-</div>
+<%= govuk_button_group_form_to 'Delete', delete_api_key_path, method: :delete, cancel_path: api_keys_path, warning: true %>

--- a/app/views/api_keys/revoke.html.erb
+++ b/app/views/api_keys/revoke.html.erb
@@ -28,7 +28,4 @@
     end
 %>
 
-<div class="govuk-button-group">
-  <%= govuk_button_to 'Revoke', revoke_api_key_path, method: :patch, class: 'govuk-button govuk-button--warning' %>
-  <%= govuk_link_to 'Cancel', api_keys_path, class: 'govuk-link' %>
-</div>
+<%= govuk_button_group_form_to 'Revoke', revoke_api_key_path, method: :patch, cancel_path: api_keys_path, warning: true %>

--- a/app/views/invitations/delete.html.erb
+++ b/app/views/invitations/delete.html.erb
@@ -25,7 +25,4 @@
     end
 %>
 
-<div class="govuk-button-group">
-  <%= govuk_button_to 'Delete', delete_invitation_path(@invitation), method: :delete, class: 'govuk-button govuk-button--warning' %>
-  <%= govuk_link_to 'Cancel', organisation_path(@invitation.organisation_id), class: 'govuk-link' %>
-</div>
+<%= govuk_button_group_form_to 'Delete', delete_invitation_path(@invitation), method: :delete, cancel_path: organisation_path(@invitation.organisation_id), warning: true %>

--- a/app/views/invitations/revoke.html.erb
+++ b/app/views/invitations/revoke.html.erb
@@ -21,7 +21,4 @@
     end
 %>
 
-<div class="govuk-button-group">
-  <%= govuk_button_to 'Revoke', invitation_path(@invitation), method: :patch, warning: true %>
-  <%= govuk_link_to 'Cancel', organisation_path(organisation.id) %>
-</div>
+<%= govuk_button_group_form_to 'Revoke', invitation_path(@invitation), method: :patch, cancel_path: organisation_path(organisation.id), warning: true %>

--- a/app/views/trade_tariff_keys/delete.html.erb
+++ b/app/views/trade_tariff_keys/delete.html.erb
@@ -26,7 +26,4 @@
   end
 %>
 
-<div class="govuk-button-group">
-  <%= govuk_button_to 'Delete', delete_trade_tariff_key_path(@trade_tariff_key), method: :delete, class: 'govuk-button govuk-button--warning' %>
-  <%= govuk_link_to 'Cancel', trade_tariff_keys_path, class: 'govuk-link' %>
-</div>
+<%= govuk_button_group_form_to 'Delete', delete_trade_tariff_key_path(@trade_tariff_key), method: :delete, cancel_path: trade_tariff_keys_path, warning: true %>

--- a/app/views/trade_tariff_keys/revoke.html.erb
+++ b/app/views/trade_tariff_keys/revoke.html.erb
@@ -27,7 +27,4 @@
     end
 %>
 
-<div class="govuk-button-group">
-  <%= govuk_button_to 'Revoke', revoke_trade_tariff_key_path(@trade_tariff_key), method: :patch, class: 'govuk-button govuk-button--warning' %>
-  <%= govuk_link_to 'Cancel', trade_tariff_keys_path, class: 'govuk-link' %>
-</div>
+<%= govuk_button_group_form_to 'Revoke', revoke_trade_tariff_key_path(@trade_tariff_key), method: :patch, cancel_path: trade_tariff_keys_path, warning: true %>

--- a/app/views/users/remove.html.erb
+++ b/app/views/users/remove.html.erb
@@ -16,7 +16,4 @@
     end
 %>
 
-<div class="govuk-button-group">
-  <%= govuk_button_to 'Remove', user_path(@user), method: :delete, warning: true %>
-  <%= govuk_button_to 'Cancel', organisation_path(current_user.organisation), method: :get, secondary: true %>
-</div>
+<%= govuk_button_group_form_to 'Remove', user_path(@user), method: :delete, cancel_path: organisation_path(current_user.organisation), warning: true %>

--- a/spec/helpers/govuk_helper_spec.rb
+++ b/spec/helpers/govuk_helper_spec.rb
@@ -1,0 +1,39 @@
+RSpec.describe GovukHelper, type: :helper do
+  describe "#govuk_button_group_form_to" do
+    subject(:button_group) do
+      helper.govuk_button_group_form_to(
+        "Revoke",
+        "/api_keys/123/revoke",
+        method: :patch,
+        cancel_path: "/api_keys",
+        warning: true,
+      )
+    end
+
+    let(:document) { Nokogiri::HTML.fragment(button_group) }
+    let(:form) { document.at_css("form") }
+    let(:group) { form.at_css(".govuk-button-group") }
+    let(:button) { group.at_css("button") }
+    let(:cancel_link) { group.at_css("a") }
+
+    it "renders a form around the GOV.UK button group", :aggregate_failures do
+      expect(form["action"]).to eq("/api_keys/123/revoke")
+      expect(form["method"]).to eq("post")
+      expect(form.at_css('input[name="_method"]')["value"]).to eq("patch")
+      expect(group).to be_present
+    end
+
+    it "renders the action as a warning GOV.UK submit button", :aggregate_failures do
+      expect(button.text).to include("Revoke")
+      expect(button["type"]).to eq("submit")
+      expect(button["class"]).to eq("govuk-button govuk-button--warning")
+      expect(button["data-module"]).to eq("govuk-button")
+    end
+
+    it "renders cancel as an aligned GOV.UK link", :aggregate_failures do
+      expect(cancel_link.text).to include("Cancel")
+      expect(cancel_link["href"]).to eq("/api_keys")
+      expect(cancel_link["class"]).to eq("govuk-link")
+    end
+  end
+end


### PR DESCRIPTION
## What changed

- Added a shared `govuk_button_group_form_to` helper for destructive confirmation actions.
- The helper renders the Rails form around a `govuk-button-group`, keeping the group markup aligned with the GOV.UK documented pattern: submit button plus `govuk-link` cancel link.
- Updated API key, invitation, Trade Tariff key, and user removal confirmation pages to use the helper.
- Added focused helper specs for the generated form, button, and cancel link markup.

## Why

The Trade Tariff key delete confirmation page paired a Rails `button_to` form with a cancel link inside the button group. Because `button_to` wraps the button in a form, the group did not match the GOV.UK documented button/link structure and the cancel link was visually out of alignment.

## Verification

- `bundle exec rspec spec/helpers/govuk_helper_spec.rb` - 3 examples, 0 failures
- `bundle exec rspec spec/helpers/govuk_helper_spec.rb spec/requests/api_keys_spec.rb spec/requests/invitations_spec.rb spec/requests/trade_tariff_keys_spec.rb spec/requests/users_spec.rb` - 60 examples, 0 failures
- `bundle exec rubocop app/helpers/govuk_helper.rb spec/helpers/govuk_helper_spec.rb` - no offenses
- `bundle exec rspec` - 520 examples, 0 failures

Note: full `bundle exec rubocop` currently fails on existing `bin/*` offenses unrelated to this change.