### PR TITLE
Redirect authenticated users past the start/home page

### DIFF
--- a/app/controllers/authenticated_controller.rb
+++ b/app/controllers/authenticated_controller.rb
@@ -2,6 +2,7 @@
 
 class AuthenticatedController < ApplicationController
   include DevBypassAuthentication
+  include SessionAuthentication
 
   before_action :require_authentication,
                 :set_paper_trail_whodunnit,
@@ -43,19 +44,6 @@ protected
     if TradeTariffDevHub.deployed_environment?
       redirect_to TradeTariffDevHub.identity_consumer_url, allow_other_host: true
     end
-  end
-
-  def authenticated?
-    return false if user_session.blank?
-    return false unless user_session.current?
-
-    # Check cookie matching only if cookie is present
-    # If no cookie is present, allow the session (cookie might not be set yet in callback flow)
-    cookie_token = cookies[TradeTariffDevHub.id_token_cookie_name]
-    return true if cookie_token.blank? # No cookie to check - allow valid session
-
-    # If cookie is present, it must match the session
-    user_session.cookie_token_match_for?(cookie_token)
   end
 
   def organisation

--- a/app/controllers/concerns/session_authentication.rb
+++ b/app/controllers/concerns/session_authentication.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module SessionAuthentication
+  extend ActiveSupport::Concern
+
+protected
+
+  def authenticated?
+    return false if user_session.blank?
+    return false unless user_session.current?
+
+    # Check cookie matching only if cookie is present
+    # If no cookie is present, allow the session (cookie might not be set yet in callback flow)
+    cookie_token = cookies[TradeTariffDevHub.id_token_cookie_name]
+    return true if cookie_token.blank? # No cookie to check - allow valid session
+
+    # If cookie is present, it must match the session
+    user_session.cookie_token_match_for?(cookie_token)
+  end
+
+  def logged_in_landing_path
+    organisation_path(user_session.user.organisation)
+  end
+end

--- a/app/controllers/homepage_controller.rb
+++ b/app/controllers/homepage_controller.rb
@@ -1,19 +1,30 @@
 class HomepageController < ApplicationController
   include DevBypassAuthentication
+  include SessionAuthentication
 
-  def index
-    # Homepage shows normally - redirect happens when user clicks "Start now"
-    # which goes to api_keys_path and triggers AuthenticatedController#require_authentication
-  end
+  before_action :redirect_authenticated_users, only: :index
+
+  def index; end
 
 protected
 
+  def redirect_authenticated_users
+    if authenticated?
+      redirect_to logged_in_landing_path and return
+    end
+
+    if dev_bypass_enabled? && dev_bypass_user_type.present?
+      user = current_user_with_dev_bypass
+      redirect_to organisation_path(user.organisation) and return if user&.organisation
+    end
+
+    clear_authentication! if user_session.present?
+  end
+
   def current_user
     @current_user ||= if dev_bypass_enabled?
-                        # Only return user if dev bypass session exists and is valid
                         current_user_with_dev_bypass
                       else
-                        # Use normal session authentication
                         Session.find_by_token(session[:token])&.user
                       end
   end

--- a/spec/controllers/homepage_controller_spec.rb
+++ b/spec/controllers/homepage_controller_spec.rb
@@ -1,8 +1,71 @@
+# frozen_string_literal: true
+
 RSpec.describe HomepageController, type: :controller do
   describe "GET #index" do
-    it "returns http success" do
-      get :index
-      expect(response).to have_http_status(:success)
+    let(:current_user) { create(:user) }
+    let(:plain_token) { SecureRandom.uuid }
+    let(:id_token_value) { "test-id-token" }
+
+    before do
+      allow(TradeTariffDevHub).to receive(:id_token_cookie_name).and_return(:id_token)
+    end
+
+    context "when user has no session" do
+      it "returns http success" do
+        get :index
+        expect(response).to have_http_status(:success)
+      end
+    end
+
+    context "when user has a valid identity session" do
+      let(:valid_verify_result) { VerifyToken::Result.new(valid: true, payload: {}, reason: nil) }
+
+      before do
+        session[:token] = plain_token
+        cookies[TradeTariffDevHub.id_token_cookie_name] = id_token_value
+        create(:session, user: current_user, token: plain_token, id_token: id_token_value)
+        allow(VerifyToken).to receive(:new).with(id_token_value).and_return(
+          instance_double(VerifyToken, call: valid_verify_result),
+        )
+      end
+
+      it "redirects to the organisation page" do
+        get :index
+        expect(response).to redirect_to(organisation_path(current_user.organisation))
+      end
+    end
+
+    context "when user has a stale identity session" do
+      let(:invalid_verify_result) { VerifyToken::Result.new(valid: false, payload: nil, reason: "expired") }
+
+      before do
+        session[:token] = plain_token
+        cookies[TradeTariffDevHub.id_token_cookie_name] = id_token_value
+        create(:session, user: current_user, token: plain_token, id_token: id_token_value)
+        allow(VerifyToken).to receive(:new).with(id_token_value).and_return(
+          instance_double(VerifyToken, call: invalid_verify_result),
+        )
+      end
+
+      it "returns http success and clears the session", :aggregate_failures do
+        get :index
+        expect(response).to have_http_status(:success)
+        expect(Session.find_by_token(plain_token)).to be_nil
+        expect(session[:token]).to be_nil
+      end
+    end
+
+    context "when user is logged in via dev bypass" do
+      before do
+        allow(TradeTariffDevHub).to receive(:dev_bypass_auth_enabled?).and_return(true)
+        session[:dev_bypass] = DevBypassAuthentication::USER_TYPE_USER
+      end
+
+      it "redirects to the dev user's organisation page" do
+        get :index
+        user = User.find_by!(email_address: DevBypassAuthentication::DEV_BYPASS_USER_EMAIL)
+        expect(response).to redirect_to(organisation_path(user.organisation))
+      end
     end
   end
 end

--- a/spec/requests/admin/role_requests_spec.rb
+++ b/spec/requests/admin/role_requests_spec.rb
@@ -200,6 +200,8 @@ RSpec.describe "Admin Role Requests", type: :request do
         get admin_role_requests_path
         expect(response).to redirect_to(root_path)
         follow_redirect!
+        expect(response).to redirect_to(organisation_path(current_user.organisation))
+        follow_redirect!
         expect(response.body).to include("does not have the required permissions to access this section")
       end
     end
@@ -213,6 +215,8 @@ RSpec.describe "Admin Role Requests", type: :request do
         get admin_role_requests_path
         expect(response).to redirect_to(root_path)
         follow_redirect!
+        expect(response).to redirect_to(organisation_path(current_user.organisation))
+        follow_redirect!
         expect(response.body).to include("This feature is currently disabled")
       end
 
@@ -221,6 +225,8 @@ RSpec.describe "Admin Role Requests", type: :request do
         post approve_admin_role_request_path(role_request)
         expect(response).to redirect_to(root_path)
         follow_redirect!
+        expect(response).to redirect_to(organisation_path(current_user.organisation))
+        follow_redirect!
         expect(response.body).to include("This feature is currently disabled")
       end
 
@@ -228,6 +234,8 @@ RSpec.describe "Admin Role Requests", type: :request do
         role_request = create(:role_request, status: "pending")
         post reject_admin_role_request_path(role_request)
         expect(response).to redirect_to(root_path)
+        follow_redirect!
+        expect(response).to redirect_to(organisation_path(current_user.organisation))
         follow_redirect!
         expect(response.body).to include("This feature is currently disabled")
       end

--- a/spec/requests/homepage_spec.rb
+++ b/spec/requests/homepage_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+RSpec.describe "Homepage", type: :request do
+  describe "GET /" do
+    context "when user has no session" do
+      it "returns http success", :aggregate_failures do
+        get root_path
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("Start now")
+      end
+    end
+
+    context "when user has a valid identity session" do
+      include_context "with authenticated user"
+
+      it "redirects to the organisation page" do
+        get root_path
+        expect(response).to redirect_to(organisation_path(current_user.organisation))
+      end
+    end
+
+    context "when user has a stale identity session" do
+      let(:current_user) { create(:user) }
+      let(:plain_token) { SecureRandom.uuid }
+      let(:id_token_value) { "stale-id-token" }
+      let(:invalid_verify_result) { VerifyToken::Result.new(valid: false, payload: nil, reason: "expired") }
+
+      before do
+        user_session = create(:session, user: current_user, token: plain_token, id_token: id_token_value)
+        allow(VerifyToken).to receive(:new).with(id_token_value).and_return(
+          instance_double(VerifyToken, call: invalid_verify_result),
+        )
+
+        env = Rack::MockRequest.env_for("/")
+        env.merge! app.env_config
+        setter = proc { |request_env| request_env["rack.session"].merge!(token: plain_token) }
+        ActionDispatch::Session::CookieStore.new(setter, key: "_trade_tariff_dev_hub_session").call(env)
+        cookies_key_value = env["action_dispatch.cookies"].as_json.first
+        cookies[TradeTariffDevHub.id_token_cookie_name] = user_session.id_token
+        cookies[cookies_key_value.first] = cookies_key_value.last
+      end
+
+      it "returns http success and clears the session", :aggregate_failures do
+        get root_path
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("Start now")
+        expect(Session.find_by_token(plain_token)).to be_nil
+      end
+    end
+
+    context "when user is logged in via dev bypass" do
+      before do
+        allow(TradeTariffDevHub).to receive_messages(
+          dev_bypass_auth_enabled?: true,
+          dev_bypass_admin_password: "admin-password",
+          dev_bypass_user_password: "user-password",
+        )
+        Rails.application.reload_routes!
+        post dev_login_path, params: { password: "user-password" }
+        follow_redirect!
+      end
+
+      it "redirects to the dev user's organisation page" do
+        get root_path
+        user = User.find_by!(email_address: DevBypassAuthentication::DEV_BYPASS_USER_EMAIL)
+        expect(response).to redirect_to(organisation_path(user.organisation))
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Jira link

https://transformuk.atlassian.net/browse/OTTIMP-619

### Summary

Returning users with an active session no longer see the start/home page when they visit /. They are taken straight to their organisation page—the same destination as after login.

Logged-out users and users with expired or invalid sessions still see the marketing homepage with “Start now” unchanged.

### Changes
- Extract shared session checks into SessionAuthentication
- Add homepage redirect for valid identity sessions and dev bypass
- Clear stale sessions on homepage visit so navigation does not treat users as signed in
- Update specs for the redirect chain (e.g. admin flows that redirect to root with a flash)
