### PR TITLE
BAU: Fixes broken secrets configuration for dev_hub_job

### DIFF
--- a/lib/tasks/cleanup.rake
+++ b/lib/tasks/cleanup.rake
@@ -3,11 +3,6 @@
 namespace :cleanup do
   desc "Delete API keys with description starting with 'playwright-' (dev only, all orgs)"
   task api_keys: :environment do
-    allowed = Rails.env.development? || ENV["CLEANUP_PLAYWRIGHT_KEYS_ENABLED"] == "true"
-    unless allowed
-      next
-    end
-
     scope = ApiKey.where("description LIKE ?", "playwright-%")
     count = scope.count
 

--- a/spec/rake/task_cleanupapi_keys_spec.rb
+++ b/spec/rake/task_cleanupapi_keys_spec.rb
@@ -1,108 +1,27 @@
-# frozen_string_literal: true
-
 require "rake"
 
-# Rake task specs: second argument is the task name, not a method (e.g. .invoke).
 # rubocop:disable RSpec/DescribeMethod
 RSpec.describe Rake::Task, "cleanup:api_keys" do
   # rubocop:enable RSpec/DescribeMethod
   before do
-    Rails.application.load_tasks if described_class.tasks.none? { |t| t.name == "cleanup:api_keys" }
+    Rails.application.load_tasks
     described_class["cleanup:api_keys"].reenable
     allow(DeleteApiKey).to receive(:new).and_return(instance_double(DeleteApiKey, call: true))
   end
 
-  context "when not in development and CLEANUP_PLAYWRIGHT_KEYS_ENABLED is not set" do
-    before do
-      allow(Rails.env).to receive(:development?).and_return(false)
-      allow(ENV).to receive(:[]).and_call_original
-      allow(ENV).to receive(:[]).with("CLEANUP_PLAYWRIGHT_KEYS_ENABLED").and_return(nil)
-    end
+  let(:admin_org) { create(:organisation, organisation_name: "Admin Dev Org") }
+  let(:non_admin_org) { create(:organisation, organisation_name: "User Dev Org") }
 
-    it "skips without deleting", :aggregate_failures do
-      count_before = ApiKey.count
-      expect { described_class["cleanup:api_keys"].invoke }.to output(/\A.*\z/m).to_stdout
-      expect(ApiKey.count).to eq(count_before)
-    end
-  end
+  it "runs cleanup for all organisations", :aggregate_failures do
+    admin_key = create(:api_key, organisation: admin_org, description: "playwright-123")
+    user_key = create(:api_key, organisation: non_admin_org, description: "playwright-456")
+    deleter = instance_double(DeleteApiKey, call: true)
+    allow(DeleteApiKey).to receive(:new).and_return(deleter)
 
-  context "when in development" do
-    let(:admin_org) { create(:organisation, organisation_name: "Admin Dev Org") }
-    let(:non_admin_org) { create(:organisation, organisation_name: "User Dev Org") }
+    expect { described_class["cleanup:api_keys"].invoke }.to output(/\A.*\z/m).to_stdout
 
-    before do
-      allow(Rails.env).to receive(:development?).and_return(true)
-      allow(ENV).to receive(:[]).and_call_original
-      allow(ENV).to receive(:[]).with("CLEANUP_PLAYWRIGHT_KEYS_ENABLED").and_return(nil)
-    end
-
-    context "when no organisations have playwright keys" do
-      it "does not call DeleteApiKey", :aggregate_failures do
-        expect { described_class["cleanup:api_keys"].invoke }.to output(/\A.*\z/m).to_stdout
-
-        expect(DeleteApiKey).not_to have_received(:new)
-      end
-    end
-
-    context "when organisations have playwright-prefixed keys" do
-      let!(:admin_playwright_key) do
-        create(:api_key, organisation: admin_org, description: "playwright-#{Time.zone.now.to_i}")
-      end
-      let!(:user_playwright_key) do
-        create(:api_key, organisation: non_admin_org, description: "playwright-test-key")
-      end
-
-      it "deletes playwright keys from all organisations", :aggregate_failures do
-        deleter = instance_double(DeleteApiKey, call: true)
-        allow(DeleteApiKey).to receive(:new).and_return(deleter)
-
-        expect { described_class["cleanup:api_keys"].invoke }.to output(/\A.*\z/m).to_stdout
-
-        expect(deleter).to have_received(:call).with(admin_playwright_key)
-        expect(deleter).to have_received(:call).with(user_playwright_key)
-      end
-    end
-
-    context "when organisations have mixed keys" do
-      let(:deleter) { instance_double(DeleteApiKey, call: true) }
-
-      before do
-        create(:api_key, organisation: admin_org, description: "playwright-test")
-        create(:api_key, organisation: admin_org, description: "My real key")
-        create(:api_key, organisation: non_admin_org, description: "playwright-user-key")
-        create(:api_key, organisation: non_admin_org, description: "User real key")
-        allow(DeleteApiKey).to receive(:new).and_return(deleter)
-      end
-
-      it "deletes only playwright keys from all organisations", :aggregate_failures do
-        expect { described_class["cleanup:api_keys"].invoke }.to output(/\A.*\z/m).to_stdout
-
-        expect(deleter).to have_received(:call).exactly(2).times
-      end
-    end
-  end
-
-  context "when CLEANUP_PLAYWRIGHT_KEYS_ENABLED=true (deployed dev)" do
-    let(:admin_org) { create(:organisation, organisation_name: "Admin Dev Org") }
-    let(:non_admin_org) { create(:organisation, organisation_name: "User Dev Org") }
-
-    before do
-      allow(Rails.env).to receive(:development?).and_return(false)
-      allow(ENV).to receive(:[]).and_call_original
-      allow(ENV).to receive(:[]).with("CLEANUP_PLAYWRIGHT_KEYS_ENABLED").and_return("true")
-    end
-
-    it "runs cleanup for all organisations", :aggregate_failures do
-      admin_key = create(:api_key, organisation: admin_org, description: "playwright-123")
-      user_key = create(:api_key, organisation: non_admin_org, description: "playwright-456")
-      deleter = instance_double(DeleteApiKey, call: true)
-      allow(DeleteApiKey).to receive(:new).and_return(deleter)
-
-      expect { described_class["cleanup:api_keys"].invoke }.to output(/\A.*\z/m).to_stdout
-
-      expect(DeleteApiKey).to have_received(:new).twice
-      expect(deleter).to have_received(:call).with(admin_key)
-      expect(deleter).to have_received(:call).with(user_key)
-    end
+    expect(DeleteApiKey).to have_received(:new).twice
+    expect(deleter).to have_received(:call).with(admin_key)
+    expect(deleter).to have_received(:call).with(user_key)
   end
 end

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -28,12 +28,12 @@ locals {
 
   devhub_service_env_vars = concat(local.secret_env_vars, local.ecs_tls_env_vars)
 
-  job_secret_value = var.enable_cleanup_job ? try(data.aws_secretsmanager_secret_version.job[0].secret_string, "{}") : "{}"
+  job_secret_value = try(data.aws_secretsmanager_secret_version.job[0].secret_string, "{}")
   job_secret_map   = jsondecode(local.job_secret_value)
-  job_secret_env_vars = var.enable_cleanup_job ? [
+  job_secret_env_vars = [
     for key, value in local.job_secret_map : {
       name  = key
       value = value
     }
-  ] : []
+  ]
 }


### PR DESCRIPTION
# Jira link

BAU

## What?

I have:

- Fixed conditional secret configuration for the dev-hub-job service (this is needed always for migrations to run before the app is deployed in production, staging and development)
- Removed duplicate conditional for cleanup job - this is handled by the event bridge schedule which is only configured in dev and staging environments and was too defensive

## Why?

I am doing this because:

- We're blocked in the middle of fixing a different issue because there is only a partial secret configured in staging/development
