### PR TITLE
Fix case for title and other places

### DIFF
--- a/app/views/homepage/index.html.erb
+++ b/app/views/homepage/index.html.erb
@@ -1,6 +1,6 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l">Trade Tariff Developer Portal</h1>
+    <h1 class="govuk-heading-l">Trade Tariff developer portal</h1>
 
     <p class="govuk-body">
       Welcome to the official Developer Portal for HMRC Trade Tariff APIs.

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -4,7 +4,7 @@
     <% if analytics_allowed? && TradeTariffDevHub.google_tag_manager_container_id.present? %>
       <%= render "shared/gtm", part: "head" %>
     <% end %>
-    <title><%= content_for(:title) || "Trade Tariff Developer Portal" %></title>
+    <title><%= content_for(:title) || "Trade Tariff developer portal" %></title>
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="mobile-web-app-capable" content="yes">
@@ -34,7 +34,7 @@
       <%= render "shared/gtm", part: "body" %>
     <% end %>
     <%= govuk_header(homepage_url: ENV.fetch("GOVUK_APP_DOMAIN", "http://localhost:3000")) %>
-    <%= govuk_service_navigation(service_name: 'Trade Tariff Developer Portal', service_url: "#") do |nav| %>
+    <%= govuk_service_navigation(service_name: 'Trade Tariff developer portal', service_url: "#") do |nav| %>
       <%= render 'layouts/navigation', header: nav %>
     <% end %>
     <div class="govuk-width-container app-width-container">

--- a/app/views/pages/cookies.html.erb
+++ b/app/views/pages/cookies.html.erb
@@ -1,4 +1,4 @@
-<h1 class="govuk-heading-xl">Cookies on the Trade Tariff Developer Portal</h1>
+<h1 class="govuk-heading-xl">Cookies on the Trade Tariff developer portal</h1>
 <p class="govuk-body">Cookies are files saved on your phone, tablet or computer when you visit a website. We use cookies to store information about how you use this website, such as the pages you visit.</p>
 
 <p class="govuk-body">

--- a/app/views/pages/privacy.html.erb
+++ b/app/views/pages/privacy.html.erb
@@ -1,7 +1,7 @@
 <h1 class="govuk-heading-xl">Privacy notice</h1>
 
 <p class="govuk-body">
-  Trade Tariff Developer Portal (the ‘service’) is provided by HM Revenue and Customs (HMRC). HMRC will be referred to as ‘we’ or ‘us’ throughout this notice.
+  Trade Tariff developer portal (the ‘service’) is provided by HM Revenue and Customs (HMRC). HMRC will be referred to as ‘we’ or ‘us’ throughout this notice.
 </p>
 
 <p class="govuk-body">We are committed to protecting the privacy and security of your personal information.</p>
@@ -52,7 +52,7 @@
 
 <p class="govuk-body">In order for the use of personal data to be lawful, we need to meet one (or more) conditions in the data protection legislation, as set out in Article 6(1) of the General Data Protection Regulation (GDPR).</p>
 
-<p class="govuk-body">For the purpose of providing the Trade Tariff Developer Portal, the relevant condition that we are meeting is ‘public task’ as specified under Article 6 (1)(e) of the GDPR.</p>
+<p class="govuk-body">For the purpose of providing the Trade Tariff developer portal, the relevant condition that we are meeting is ‘public task’ as specified under Article 6 (1)(e) of the GDPR.</p>
 
 <h2 class="govuk-heading-m">Who we share your data with</h2>
 

--- a/spec/requests/pages_spec.rb
+++ b/spec/requests/pages_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "Pages", type: :request do
       get "/cookies"
 
       expect(response).to have_http_status(:ok)
-      expect(response.body).to include("Cookies on the Trade Tariff Developer Portal")
+      expect(response.body).to include("Cookies on the Trade Tariff developer portal")
       expect(response.body).to include("Cookies that measure website use")
     end
   end


### PR DESCRIPTION
# Jira link

https://transformuk.atlassian.net/browse/OTTIMP-566

### What?

I have:

- Updated the service name from Trade Tariff Developer Portal to Trade Tariff developer portal wherever it appears with the full “Trade Tariff” prefix (page title, service navigation, homepage heading, cookies and privacy copy, and matching request spec)

## Why?
I am doing this because:

- HMRC naming expects developer portal in sentence case (lowercase “developer”), not title case
- The full product name should be consistent across user-facing UI and legal/cookie pages
- Standalone “Developer Portal” wording is unchanged; only the branded Trade Tariff … form was updated
