### PR TITLE
BAU: Opt database apps into full deploy

### DIFF
--- a/.github/workflows/deploy-to-development-full.yml
+++ b/.github/workflows/deploy-to-development-full.yml
@@ -26,6 +26,7 @@ jobs:
         [
           {
             "name": "tariff-dev-hub",
+            "migrate": true,
             "service-names": ["dev-hub"]
           },
           {
@@ -35,6 +36,7 @@ jobs:
           },
           {
             "name": "tariff-backend",
+            "migrate": true,
             "repo": "trade-tariff/trade-tariff-backend",
             "service-names": ["backend-uk", "worker-uk"]
           }


### PR DESCRIPTION
## What

Opt database-backed apps into full deploy migrations under the new `deploy-multi-ecs` convention.

## Why

The reusable workflow now treats migrations as an explicit per-app opt-in, so callers need to mark only apps that can run the Rails migration action.
