### PR TITLE
Add SimpleCov coverage reporting to dev-hub test suite

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,6 +43,7 @@ group :test do
   gem "rspec-json_expectations"
   gem "rspec-rails"
   gem "shoulda-matchers"
+  gem "simplecov"
   gem "webmock"
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -113,6 +113,7 @@ GEM
     crass (1.0.6)
     date (3.5.1)
     diff-lcs (1.6.2)
+    docile (1.4.1)
     dotenv (3.1.8)
     dotenv-rails (3.1.8)
       dotenv (= 3.1.8)
@@ -378,6 +379,12 @@ GEM
     securerandom (0.4.1)
     shoulda-matchers (7.0.1)
       activesupport (>= 7.1)
+    simplecov (0.22.0)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.13.2)
+    simplecov_json_formatter (0.1.4)
     stringio (3.2.0)
     thor (1.5.0)
     timeout (0.6.1)
@@ -446,6 +453,7 @@ DEPENDENCIES
   rubocop-govuk
   ruby-lsp-rails
   shoulda-matchers
+  simplecov
   webmock
 
 RUBY VERSION

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,6 +1,12 @@
 require "spec_helper"
 ENV["RAILS_ENV"] ||= "test"
 ENV["ENVIRONMENT"] ||= "test" # Not live production; key limits and deploy-specific behaviour stay off in test
+ENV["DISABLE_BOOTSNAP_COMPILE_CACHE"] ||= "1" # SimpleCov starts Ruby coverage before Rails boots
+
+require "simplecov"
+
+SimpleCov.start "rails"
+SimpleCov.formatters = SimpleCov::Formatter::HTMLFormatter
 
 # Stub dev_bypass_auth_enabled? before loading environment so routes are available
 # This allows the conditional routes in config/routes.rb to be loaded in test


### PR DESCRIPTION
# Jira link

N/A

## What?

Added SimpleCov coverage reporting to `trade-tariff-dev-hub` test suite

## Why?

This gives `dev-hub` the local test coverage visibility
