### PR TITLE
Remove mention of UK in titles

### DIFF
--- a/app/views/homepage/index.html.erb
+++ b/app/views/homepage/index.html.erb
@@ -24,7 +24,7 @@
 
     <%= govuk_list type: :bullet  do %>
       <%= tag.li do %>
-        <%= tag.strong("Trade Tariff API") %> – Access UK Trade Tariff data for imports and exports.
+        <%= tag.strong("Trade Tariff API") %> – Access Trade Tariff data for imports and exports.
       <% end %>
       <%= tag.li do %>
         <%= tag.strong("Fast Parcel Operator (FPO) API") %> – Identify likely commodity codes from product descriptions to support rapid customs processing.
@@ -35,7 +35,7 @@
 
     <h3 class="govuk-heading-m">Who is this service for</h3>
     <p class="govuk-body">
-      Anyone who needs access to UK Trade Tariff data — including:
+      Anyone who needs access to Trade Tariff data — including:
     </p>
 
     <%= govuk_list [
@@ -52,7 +52,7 @@
 
     <h3 class="govuk-heading-m">Help using the APIs</h3>
     <p class="govuk-body">
-      For information, guidance and examples of using the Trade Tariff API can be found in the <%= documentation_link %>.
+      For information, guidance and examples of using the Trade Tariff APIs can be found in the <%= documentation_link %>.
     </p>
   </div>
 </div>


### PR DESCRIPTION
# Jira link

https://transformuk.atlassian.net/browse/OTTIMP-458

## What?

Remove where 'UK' is used on home page
