### PR TITLE
HMRC-2298: ActionController::InvalidAuthenticityToken in dev-portal

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,6 +2,18 @@ class ApplicationController < ActionController::Base
   default_form_builder GOVUKDesignSystemFormBuilder::FormBuilder
   allow_browser versions: :modern
 
+  # Override handling CSRF verification failures, marking security scanner probes as expected
+  def handle_unverified_request
+    if request.referer&.include?("detectify.com/bot") && request.delete?
+      # Mark as expected error for Detectify scanner probes
+      NewRelic::Agent.set_notice_error(
+        ActionController::InvalidAuthenticityToken.new("Can't verify CSRF token authenticity."),
+        { expected: true },
+      )
+    end
+    super
+  end
+
   # NOTE: Cleanup of all authentication state:
   # 1. Database Session record
   # 2. Rails session variables

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,18 +2,6 @@ class ApplicationController < ActionController::Base
   default_form_builder GOVUKDesignSystemFormBuilder::FormBuilder
   allow_browser versions: :modern
 
-  # Override handling CSRF verification failures, marking security scanner probes as expected
-  def handle_unverified_request
-    if request.referer&.include?("detectify.com/bot") && request.delete?
-      # Mark as expected error for Detectify scanner probes
-      NewRelic::Agent.set_notice_error(
-        ActionController::InvalidAuthenticityToken.new("Can't verify CSRF token authenticity."),
-        { expected: true },
-      )
-    end
-    super
-  end
-
   # NOTE: Cleanup of all authentication state:
   # 1. Database Session record
   # 2. Rails session variables

--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -1,4 +1,6 @@
 class ErrorsController < ApplicationController
+  skip_forgery_protection only: %i[not_found bad_request not_implemented]
+
   def not_found
     message = "If you typed the web address, check it is correct."
     render_error(status: :not_found, header: "Page not found", message:, json_error: "Resource not found")


### PR DESCRIPTION
## What:
- Added NewRelic handle_unverified_request method to mark CSRF verification failures in security scanner probes as expected

## Why:
Detectify security scanner checks are marked as CSRF violation error as it send DELETE /RANDOMSTRING.txt request which is not mapped in routes. Then catch-all route  "*path", to: "errors#not_found" catches it. Since it's a DELETE request, Rails validates the CSRF token. The request has no CSRF token, detectify scanners/bots might not  include CSRF token. This is working as intended and application behavior itself is correct.

## Ticket:
https://transformuk.atlassian.net/browse/HMRC-2298

## Risk:
**Risk level:** 🟠

**Reason for rating:**
This changes affect overall CSRF validation
