### PR TITLE
Fix - login invalid-password handling

### DIFF
--- a/app/controllers/dev_auth_controller.rb
+++ b/app/controllers/dev_auth_controller.rb
@@ -15,7 +15,7 @@ class DevAuthController < ApplicationController
       session.delete(:return_to) # Clear return_to but don't use it
       redirect_to default_redirect_path(user_type)
     else
-      flash[:alert] = "Invalid password"
+      flash.now[:alert] = "Invalid password"
       render :new, status: :unprocessable_content
     end
   end

--- a/app/views/dev_auth/new.html.erb
+++ b/app/views/dev_auth/new.html.erb
@@ -1,3 +1,5 @@
+<% content_for :hide_layout_flashes, true %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l">Dev Login</h1>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -47,7 +47,7 @@
         <%= yield :back_link %>
       <% end %>
       <main class="govuk-main-wrapper app-main-class" id="main-content">
-        <%= render 'flashes' %>
+        <%= render 'flashes' unless content_for?(:hide_layout_flashes) %>
         <%= yield %>
       </main>
     </div>

--- a/spec/requests/dev_auth_spec.rb
+++ b/spec/requests/dev_auth_spec.rb
@@ -73,6 +73,8 @@ RSpec.describe "Dev Auth", type: :request do
       expect(response).to have_http_status(:unprocessable_content)
       expect(response.body).to include("Dev Login")
       expect(response.body).to include("Invalid password")
+      expect(response.body.scan("Invalid password").count).to eq(1)
+      expect(response.body.index("Invalid password")).to be > response.body.index("Dev Login")
     end
 
     it "does not set session for invalid password" do
@@ -80,6 +82,21 @@ RSpec.describe "Dev Auth", type: :request do
       # Verify session is not set by trying to access a protected page
       get api_keys_path
       expect(response).to redirect_to(dev_login_path)
+    end
+
+    it "does not show a previous invalid password error after successful login", :aggregate_failures do
+      post dev_login_path, params: { password: "wrong-password" }
+      expect(response.body).to include("Invalid password")
+
+      post dev_login_path, params: { password: "user-password" }
+      user = User.find_by(email_address: "dev@transformuk.com")
+
+      expect(response).to redirect_to(organisation_path(user.organisation))
+      expect(flash[:alert]).to be_nil
+
+      follow_redirect!
+      expect(response).to have_http_status(:ok)
+      expect(response.body).not_to include("Invalid password")
     end
 
     it "renders new template with error for blank password", :aggregate_failures do


### PR DESCRIPTION
# Pull Request

## What
Fixed login invalid-password handling

## Why
When an invalid password was submitted, the alert was stored in normal flash, so it could leak into the next successful login redirect. The dev login view also rendered the same alert both from the layout and locally, causing a duplicate banner.

## Ticket
[HMRC-2383](https://transformuk.atlassian.net/browse/HMRC-2383)

## Risk

**Risk level:** 🟢 

**Reason for rating:**
The change is only scoped to dev bypass login behaviour
