### PR TITLE
Allow New Relic beacon and GTM eval in CSP

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -14,14 +14,16 @@ Rails.application.configure do
                        "https://*.google-analytics.com",
                        "https://*.analytics.google.com"
     policy.object_src  :none
-    policy.script_src  :self, :https,
+    # unsafe-eval is required by Google Tag Manager
+    policy.script_src  :self, :https, :unsafe_eval,
                        "https://www.googletagmanager.com",
                        "https://www.google-analytics.com"
     policy.connect_src :self,
                        "https://www.google-analytics.com",
                        "https://*.analytics.google.com",
                        "https://*.googletagmanager.com",
-                       "https://*.google-analytics.com"
+                       "https://*.google-analytics.com",
+                       "https://*.nr-data.net"
     policy.frame_src   :self, "https://www.googletagmanager.com"
     policy.style_src   :self, :https
     # Specify URI for violation reports


### PR DESCRIPTION
## What:
Update the Content Security Policy to allow New Relic's browser agent and Google Tag Manager to function without CSP violations.

## Why:
Two violations observed in production:

1. **New Relic** — the browser agent sends performance/error data to `bam.eu01.nr-data.net`, which was not in `connect-src`. Added `https://*.nr-data.net` to cover both EU and US ingest endpoints.
2. **GTM** — uses `eval()` at runtime to execute tags; `script-src` was missing `'unsafe-eval'`, causing violations on every page load (same issue fixed in the frontend app).

## Ticket:
N/A

## Risk:

**Risk level:** 🟢

**Reason for rating:**
Config-only change to the CSP initializer. The policy remains in `report_only` mode so there is no enforcement risk; this reduces violation noise and prepares the policy for future enforcement.