### PR TITLE
Remove dead Dependabot npm config from dev-hub

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,10 +14,3 @@ updates:
       interval: weekly
     cooldown:
       default-days: 7
-
-  - package-ecosystem: npm
-    directory: /
-    schedule:
-      interval: weekly
-    cooldown:
-      default-days: 7


### PR DESCRIPTION
### What?

I have added/removed/altered:

- [x] Removed the `npm` package-ecosystem block from `.github/dependabot.yml`

### Why?

I am doing this because:

- dev-hub has no `package.json`, so Dependabot had nothing to update
- Prevents empty or failed npm Dependabot PRs

## Risk

**Risk level:** 🟢 

**Reason for rating:**
This only changes Dependabot config in dev-hub. It does not touch app code, dependencies, deploys, or runtime behaviour. The repo has no package.json, so the npm block was already doing nothing useful — removing it just stops Dependabot from trying (and possibly failing) to open npm update PRs.



