### PR TITLE
ci: enable rubocop annotations for pre-commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,8 @@ jobs:
       - run: cd terraform/ && terraform init -backend=false -reconfigure
       - run: pip install pre-commit
       - run: pre-commit run --all-files --hook-stage pre-commit
+        env:
+          RUBOCOP_OPTS: --format github
       - run: pre-commit run --all-files --hook-stage pre-push
       - run: bundle exec brakeman
 


### PR DESCRIPTION
## What

- Sets `RUBOCOP_OPTS=--format github` for pre-commit runs in GitHub Actions so RuboCop can emit GitHub Actions annotations while keeping local hook behavior unchanged.

## Why

The Rails `bin/ci` setup runs with `CI=true`, and the pre-commit CI path was not passing RuboCop GitHub formatter options. This makes RuboCop failures from pre-commit easier to review inline in PRs.

## Ticket

N/A

## Risk

**Risk level:** 🟢

**Reason for rating:**
Low risk. This only changes CI lint reporting configuration and does not affect application runtime or deployment behaviour.
