### PR TITLE
Fix orphaned AWS usage plan association when api_key.save! fails

### DIFF
--- a/app/services/create_api_key.rb
+++ b/app/services/create_api_key.rb
@@ -13,6 +13,7 @@ class CreateApiKey
 
   def initialize(api_gateway_client = nil)
     @api_gateway_client = api_gateway_client || Aws::APIGateway::Client.new
+    @newly_created_usage_plan_id = nil
   end
 
   def call(api_key)
@@ -27,11 +28,20 @@ class CreateApiKey
     rescue StandardError => e
       Rails.logger.error("Error creating API key: #{e.message}")
       if api_key.api_gateway_id
+        if @newly_created_usage_plan_id
+          begin
+            api_gateway_client.delete_usage_plan(usage_plan_id: @newly_created_usage_plan_id)
+          rescue StandardError => delete_error
+            Rails.logger.error("Failed to delete usage plan #{@newly_created_usage_plan_id} from AWS: #{delete_error.message}")
+          end
+        end
+
         begin
           api_gateway_client.delete_api_key(api_key_id: api_key.api_gateway_id)
         rescue StandardError => delete_error
           Rails.logger.error("Failed to delete API key #{api_key.api_gateway_id} from AWS: #{delete_error.message}")
         end
+
         api_key.destroy! if api_key.persisted?
       end
 
@@ -99,7 +109,7 @@ private
       api_stages: [{ api_id: REST_API_ID, stage: STAGE_NAME }],
       tags: TAGS,
     )
-    response.id
+    @newly_created_usage_plan_id = response.id
   end
 
   def generate_client_id

--- a/spec/services/create_api_key_spec.rb
+++ b/spec/services/create_api_key_spec.rb
@@ -46,5 +46,51 @@ RSpec.describe CreateApiKey do
       create_api_key.call(api_key)
       expect(api_gateway_client).not_to have_received(:create_usage_plan)
     end
+
+    context "when save! fails after using a pre-existing usage plan" do
+      before do
+        allow(api_key).to receive(:save!).and_raise(ActiveRecord::RecordInvalid)
+        allow(api_gateway_client).to receive(:delete_api_key)
+        allow(api_gateway_client).to receive(:delete_usage_plan)
+        create_api_key.call(api_key)
+      rescue ActiveRecord::RecordInvalid
+        nil
+      end
+
+      it "deletes the API Gateway key from AWS" do
+        expect(api_gateway_client).to have_received(:delete_api_key).with(
+          api_key_id: "api-gateway-id-123",
+        )
+      end
+
+      it "does not delete the pre-existing usage plan" do
+        expect(api_gateway_client).not_to have_received(:delete_usage_plan)
+      end
+    end
+
+    context "when save! fails after a new usage plan was created" do
+      before do
+        api_gateway_client.stub_responses(:get_usage_plans, items: [], position: nil)
+        api_gateway_client.stub_responses(:create_usage_plan, id: "new-plan-id-789")
+        allow(api_key).to receive(:save!).and_raise(ActiveRecord::RecordInvalid)
+        allow(api_gateway_client).to receive(:delete_api_key)
+        allow(api_gateway_client).to receive(:delete_usage_plan)
+        create_api_key.call(api_key)
+      rescue ActiveRecord::RecordInvalid
+        nil
+      end
+
+      it "deletes the newly created usage plan from AWS" do
+        expect(api_gateway_client).to have_received(:delete_usage_plan).with(
+          usage_plan_id: "new-plan-id-789",
+        )
+      end
+
+      it "also deletes the API Gateway key from AWS" do
+        expect(api_gateway_client).to have_received(:delete_api_key).with(
+          api_key_id: "api-gateway-id-123",
+        )
+      end
+    end
   end
 end


### PR DESCRIPTION
## What
Extend the rollback in `CreateApiKey#call` to delete a newly created AWS usage plan if `api_key.save!` fails. Previously, if no usage plan existed for an org yet, one would be created in API Gateway and then left permanently orphaned if the DB save failed. Also removes a redundant `delete_usage_plan_key` call — AWS cleans up key associations automatically when the plan or key is deleted.

## Why
Repeated `save!` failures (e.g. a DB constraint violation) would silently accumulate orphaned usage plans in API Gateway, consuming quota and causing confusion during debugging.

## Ticket
[HMRC-2456](https://transformuk.atlassian.net/browse/HMRC-2456)

## Risk

**Risk level:** 🟢

**Reason for rating:**
Rollback-only path change in the error rescue block — no changes to the happy path for creating, listing, or revoking API keys. New behaviour only fires when `save!` has already failed.