### PR TITLE
[HMRC-2449] Add github workflow for importmap updates

### DIFF
--- a/.github/workflows/importmap-update.yml
+++ b/.github/workflows/importmap-update.yml
@@ -1,0 +1,18 @@
+name: Importmap updates
+
+on:
+  schedule:
+    - cron: "0 9 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: trade-tariff/trade-tariff-tools/.github/actions/importmap-update@main
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What:
Adds workflow for dependabot style importmap updates using [https://github.com/trade-tariff/trade-tariff-tools/blob/main/.github/actions/importmap-update/action.yml](https://github.com/trade-tariff/trade-tariff-tools/blob/main/.github/actions/importmap-update/action.yml)

## Why:
Dependabot does not support importmaps so we should have an equivalent automated process for importmap updates.

## Ticket:
[HMRC-2449](https://transformuk.atlassian.net/browse/HMRC-2449)

## Risk:

Risk level: 🟢

## Reason for rating:
Adds workflow, no changes to existing code