### PR TITLE
Trigger auto-merge when PRs leave draft

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -3,6 +3,7 @@ name: Auto-merge low-risk PRs
 on:
   pull_request:
     types:
+      - ready_for_review
       - labeled
       - unlabeled
   pull_request_review:
@@ -22,8 +23,14 @@ permissions:
 jobs:
   auto-merge:
     if: >-
-      github.event_name != 'pull_request_review' ||
-      github.event.review.user.login == 'copilot-pull-request-reviewer[bot]'
+      (
+        github.event_name != 'pull_request' ||
+        !github.event.pull_request.draft
+      ) &&
+      (
+        github.event_name != 'pull_request_review' ||
+        github.event.review.user.login == 'copilot-pull-request-reviewer[bot]'
+      )
     uses: trade-tariff/trade-tariff-tools/.github/workflows/auto-merge-low-risk.yml@main
     with:
       label: low-risk


### PR DESCRIPTION
## What

- Add `ready_for_review` to the low-risk auto-merge workflow pull request triggers.
- Add a caller-side draft guard so draft `pull_request` events do not invoke the reusable auto-merge workflow.

## Why

Promoting a draft PR to ready for review should give the existing low-risk auto-merge workflow another chance to run. Draft PRs should not call into the reusable auto-merge workflow from pull request events.

## Ticket

N/A

## Tested

- Verified `.github/workflows/auto-merge.yml` contains `ready_for_review` and the draft guard on this branch.
- Ran `actionlint` against the updated workflow content.

## Risk

**Risk level:** 🟢

**Reason for rating:** Low-risk workflow trigger change. This does not alter the reusable auto-merge workflow implementation, permissions, secrets, or application code; it only triggers the existing workflow when a PR is marked ready for review, while keeping draft pull request events guarded.