### PR TITLE
Enforce single concurrent session per user (HMRC-1239)

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -61,7 +61,7 @@ private
 
   def create_user_session!(user, payload)
     invalidated = Session.invalidate_for_user!(user)
-    if invalidated > 0
+    if invalidated.positive?
       Rails.logger.warn("[Auth] Concurrent session detected for #{user.email_address}: invalidated #{invalidated} existing session(s)")
     end
 

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -60,6 +60,11 @@ class SessionsController < ApplicationController
 private
 
   def create_user_session!(user, payload)
+    invalidated = Session.invalidate_for_user!(user)
+    if invalidated > 0
+      Rails.logger.warn("[Auth] Concurrent session detected for #{user.email_address}: invalidated #{invalidated} existing session(s)")
+    end
+
     Session.create!(
       user: user,
       token: session_token,

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -38,6 +38,13 @@ class Session < ApplicationRecord
     find_by(token: digest(token))
   end
 
+  def self.invalidate_for_user!(user)
+    sessions = where(user: user)
+    count = sessions.count
+    sessions.destroy_all
+    count
+  end
+
   def current?
     !renew?
   end

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe SessionsController, type: :controller do
       context "when the user already has an active session" do
         let!(:existing_session) { create(:session, user: user) }
 
-        it "destroys the existing session before creating a new one" do
+        it "destroys the existing session before creating a new one", :aggregate_failures do
           expect { get :handle_redirect }.not_to change(Session, :count)
 
           expect(Session.exists?(id: existing_session.id)).to be(false)

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -57,6 +57,25 @@ RSpec.describe SessionsController, type: :controller do
         expect(Session.last.id_token).to eq("encoded-token")
       end
 
+      context "when the user already has an active session" do
+        let!(:existing_session) { create(:session, user: user) }
+
+        it "destroys the existing session before creating a new one" do
+          expect { get :handle_redirect }.not_to change(Session, :count)
+
+          expect(Session.exists?(id: existing_session.id)).to be(false)
+          expect(Session.where(user: user).count).to eq(1)
+        end
+
+        it "logs the concurrent session invalidation" do
+          allow(Rails.logger).to receive(:warn)
+
+          get :handle_redirect
+
+          expect(Rails.logger).to have_received(:warn).with(/\[Auth\].*concurrent.*user@example\.com/i)
+        end
+      end
+
       it "stores a hashed session token" do
         get :handle_redirect
 

--- a/spec/models/session_spec.rb
+++ b/spec/models/session_spec.rb
@@ -53,6 +53,49 @@ RSpec.describe Session, type: :model do
     end
   end
 
+  describe ".invalidate_for_user!" do
+    context "when the user has existing sessions" do
+      it "destroys all sessions for that user" do
+        user = create(:user)
+        create_list(:session, 2, user: user)
+
+        described_class.invalidate_for_user!(user)
+
+        expect(described_class.where(user: user).count).to eq(0)
+      end
+
+      it "returns the number of sessions destroyed" do
+        user = create(:user)
+        create_list(:session, 3, user: user)
+
+        count = described_class.invalidate_for_user!(user)
+
+        expect(count).to eq(3)
+      end
+
+      it "does not destroy sessions belonging to other users" do
+        user = create(:user)
+        other_user = create(:user)
+        create(:session, user: user)
+        other_session = create(:session, user: other_user)
+
+        described_class.invalidate_for_user!(user)
+
+        expect(described_class.exists?(id: other_session.id)).to be(true)
+      end
+    end
+
+    context "when the user has no existing sessions" do
+      it "returns 0" do
+        user = create(:user)
+
+        count = described_class.invalidate_for_user!(user)
+
+        expect(count).to eq(0)
+      end
+    end
+  end
+
   describe "#renew?" do
     it "returns true when the token cannot be verified" do
       session = build(:session)

--- a/spec/requests/sessions_spec.rb
+++ b/spec/requests/sessions_spec.rb
@@ -4,8 +4,9 @@ RSpec.describe "Sessions", type: :request do
   describe "GET /auth/redirect" do
     let(:extra_session) { {} }
 
-    it "creates a Session" do
-      expect { get auth_redirect_path }.to change(Session, :count).by(1)
+    it "creates a Session for the user, replacing any existing ones" do
+      get auth_redirect_path
+      expect(Session.where(user: current_user).count).to eq(1)
     end
 
     it "redirects the user to their organisation page" do


### PR DESCRIPTION
# Jira link

[HMRC-1239](https://transformuk.atlassian.net/browse/HMRC-1239)

## What?

I have:

- [x] Added `Session.invalidate_for_user!(user)` — destroys all existing sessions for a user account and returns the count destroyed
- [x] Added concurrent session invalidation to `SessionsController#create_user_session!` — any pre-existing sessions for the user are terminated before the new session is created
- [x] Added audit logging: a `warn`-level `[Auth] Concurrent session detected...` log entry is written whenever existing sessions are invalidated
- [x] Added tests for the new behaviour and updated one existing request spec whose assertion assumed no pre-existing session

## Why?

Penetration test risk **RO6** (Risk Treatment Plan 06-2025) found that the application allowed a user account to remain logged in across multiple devices simultaneously. An attacker with a compromised session token could stay active alongside the legitimate user with no indication to either party.

Treatment option a from the RTP: terminate the original active session when a new login occurs, and emit an audit log entry for concurrent login attempts.

## Risk rating

🟢 **Reason for rating:** Change is confined to the identity service OAuth callback path (`SessionsController#handle_redirect`). Existing authenticated sessions are unaffected — only new logins trigger the cleanup. All 48 auth specs pass. No API or schema changes.