### PR TITLE
Add session inactivity and absolute lifetime timeouts (HMRC-1236)

### DIFF
--- a/app/controllers/authenticated_controller.rb
+++ b/app/controllers/authenticated_controller.rb
@@ -20,6 +20,7 @@ protected
   def require_authentication
     # Check for identity authentication first (works in all environments)
     if authenticated?
+      user_session&.touch_last_active!
       handle_user_session
       return
     end

--- a/app/controllers/concerns/session_authentication.rb
+++ b/app/controllers/concerns/session_authentication.rb
@@ -7,6 +7,7 @@ protected
 
   def authenticated?
     return false if user_session.blank?
+    return false if user_session.app_session_timed_out?
     return false unless user_session.current?
 
     cookie_token = cookies[TradeTariffDevHub.id_token_cookie_name]

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -65,11 +65,14 @@ private
       Rails.logger.warn("[Auth] Concurrent session detected for #{user.email_address}: invalidated #{invalidated} existing session(s)")
     end
 
+    now = Time.current
     Session.create!(
       user: user,
       token: session_token,
       id_token: id_token,
       raw_info: payload,
+      expires_at: now + Session::ABSOLUTE_LIFETIME,
+      last_active_at: now,
     )
   end
 
@@ -87,6 +90,7 @@ private
 
   def already_authenticated?
     return false if user_session.blank?
+    return false if user_session.app_session_timed_out?
     return false unless user_session.current?
 
     # Check cookie matching only if cookie is present

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -6,6 +6,7 @@
 #  token                   :string           not null
 #  user_id                 :uuid             not null
 #  expires_at              :datetime
+#  last_active_at          :datetime
 #  raw_info                :jsonb
 #  created_at              :datetime         not null
 #  updated_at              :datetime         not null
@@ -20,6 +21,9 @@
 #
 
 class Session < ApplicationRecord
+  ABSOLUTE_LIFETIME = 4.hours
+  INACTIVITY_TIMEOUT = 15.minutes
+
   belongs_to :user
   belongs_to :assumed_organisation, class_name: "Organisation", optional: true
 
@@ -53,11 +57,27 @@ class Session < ApplicationRecord
     !verify_id_token.valid?
   end
 
+  def app_session_timed_out?
+    absolute_lifetime_exceeded? || inactive?
+  end
+
+  def touch_last_active!
+    update_column(:last_active_at, Time.current)
+  end
+
   def cookie_token_match_for?(cookie_token)
     id_token == cookie_token.to_s
   end
 
 private
+
+  def absolute_lifetime_exceeded?
+    expires_at.present? && Time.current >= expires_at
+  end
+
+  def inactive?
+    last_active_at.present? && Time.current >= last_active_at + INACTIVITY_TIMEOUT
+  end
 
   def verify_id_token
     @verify_id_token ||= VerifyToken.new(id_token).call

--- a/db/migrate/20260728000000_add_last_active_at_to_sessions.rb
+++ b/db/migrate/20260728000000_add_last_active_at_to_sessions.rb
@@ -1,0 +1,17 @@
+class AddLastActiveAtToSessions < ActiveRecord::Migration[8.1]
+  def change
+    add_column :sessions, :last_active_at, :datetime
+
+    # Backfill existing rows: treat updated_at as last activity, created_at + 4h as expiry
+    reversible do |dir|
+      dir.up do
+        execute <<~SQL
+          UPDATE sessions
+          SET last_active_at = updated_at,
+              expires_at     = created_at + INTERVAL '4 hours'
+          WHERE last_active_at IS NULL
+        SQL
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_09_154738) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_28_000000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pgcrypto"
@@ -92,6 +92,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_09_154738) do
     t.datetime "created_at", null: false
     t.datetime "expires_at"
     t.text "id_token", null: false
+    t.datetime "last_active_at", precision: nil
     t.jsonb "raw_info"
     t.string "token", null: false
     t.datetime "updated_at", null: false

--- a/spec/controllers/authenticated_controller_spec.rb
+++ b/spec/controllers/authenticated_controller_spec.rb
@@ -183,14 +183,13 @@ RSpec.describe AuthenticatedController, type: :controller do
 
     context "when updating last activity" do
       let(:valid_verify_result) { VerifyToken::Result.new(valid: true, payload: {}, reason: nil) }
-      let(:user_session) { create(:session, user: current_user, token: plain_token, id_token: id_token_value) }
 
       before do
+        @session_record = create(:session, user: current_user, token: plain_token, id_token: id_token_value)
         allow(TradeTariffDevHub).to receive_messages(
           deployed_environment?: false,
           block_non_fpo_identity_sessions_in_production?: false,
         )
-        user_session
         session[:token] = plain_token
         cookies[TradeTariffDevHub.id_token_cookie_name] = id_token_value
         allow(VerifyToken).to receive(:new).with(id_token_value).and_return(
@@ -200,7 +199,7 @@ RSpec.describe AuthenticatedController, type: :controller do
 
       it "updates last_active_at on each authenticated request" do
         get :test_action
-        expect(user_session.reload.last_active_at).to be_within(2.seconds).of(Time.current)
+        expect(@session_record.reload.last_active_at).to be_within(2.seconds).of(Time.current)
       end
     end
   end

--- a/spec/controllers/authenticated_controller_spec.rb
+++ b/spec/controllers/authenticated_controller_spec.rb
@@ -180,5 +180,28 @@ RSpec.describe AuthenticatedController, type: :controller do
         expect(response).to have_http_status(:ok)
       end
     end
+
+    context "when updating last activity" do
+      let(:valid_verify_result) { VerifyToken::Result.new(valid: true, payload: {}, reason: nil) }
+      let(:user_session) { create(:session, user: current_user, token: plain_token, id_token: id_token_value) }
+
+      before do
+        allow(TradeTariffDevHub).to receive_messages(
+          deployed_environment?: false,
+          block_non_fpo_identity_sessions_in_production?: false,
+        )
+        user_session
+        session[:token] = plain_token
+        cookies[TradeTariffDevHub.id_token_cookie_name] = id_token_value
+        allow(VerifyToken).to receive(:new).with(id_token_value).and_return(
+          instance_double(VerifyToken, call: valid_verify_result),
+        )
+      end
+
+      it "updates last_active_at on each authenticated request" do
+        get :test_action
+        expect(user_session.reload.last_active_at).to be_within(2.seconds).of(Time.current)
+      end
+    end
   end
 end

--- a/spec/controllers/authenticated_controller_spec.rb
+++ b/spec/controllers/authenticated_controller_spec.rb
@@ -185,7 +185,7 @@ RSpec.describe AuthenticatedController, type: :controller do
       let(:valid_verify_result) { VerifyToken::Result.new(valid: true, payload: {}, reason: nil) }
 
       before do
-        @session_record = create(:session, user: current_user, token: plain_token, id_token: id_token_value)
+        create(:session, user: current_user, token: plain_token, id_token: id_token_value)
         allow(TradeTariffDevHub).to receive_messages(
           deployed_environment?: false,
           block_non_fpo_identity_sessions_in_production?: false,
@@ -199,7 +199,8 @@ RSpec.describe AuthenticatedController, type: :controller do
 
       it "updates last_active_at on each authenticated request" do
         get :test_action
-        expect(@session_record.reload.last_active_at).to be_within(2.seconds).of(Time.current)
+        updated_session = Session.find_by_token(plain_token)
+        expect(updated_session.last_active_at).to be_within(2.seconds).of(Time.current)
       end
     end
   end

--- a/spec/controllers/concerns/session_authentication_spec.rb
+++ b/spec/controllers/concerns/session_authentication_spec.rb
@@ -13,23 +13,25 @@ RSpec.describe SessionAuthentication, type: :controller do
 
   before do
     routes.draw { get "index" => "anonymous#index" }
+    allow(TradeTariffDevHub).to receive(:id_token_cookie_name).and_return(:id_token)
   end
 
   let(:current_user) { create(:user) }
   let(:plain_token) { SecureRandom.uuid }
   let(:id_token_value) { "test-id-token" }
 
-  before do
-    allow(TradeTariffDevHub).to receive(:id_token_cookie_name).and_return(:id_token)
-  end
-
   describe "#authenticated?" do
     context "when the session has exceeded the 4-hour absolute lifetime" do
       it "returns false" do
-        create(:session, user: current_user, token: plain_token, id_token: id_token_value,
-               expires_at: 1.second.ago, last_active_at: 1.minute.ago)
+        create(
+          :session,
+          user: current_user,
+          token: plain_token,
+          id_token: id_token_value,
+          expires_at: 1.second.ago,
+          last_active_at: 1.minute.ago,
+        )
         session[:token] = plain_token
-        cookies[:id_token] = id_token_value
 
         expect(controller.send(:authenticated?)).to be(false)
       end
@@ -37,10 +39,15 @@ RSpec.describe SessionAuthentication, type: :controller do
 
     context "when the session has been inactive for more than 15 minutes" do
       it "returns false" do
-        create(:session, user: current_user, token: plain_token, id_token: id_token_value,
-               expires_at: 2.hours.from_now, last_active_at: 16.minutes.ago)
+        create(
+          :session,
+          user: current_user,
+          token: plain_token,
+          id_token: id_token_value,
+          expires_at: 2.hours.from_now,
+          last_active_at: 16.minutes.ago,
+        )
         session[:token] = plain_token
-        cookies[:id_token] = id_token_value
 
         expect(controller.send(:authenticated?)).to be(false)
       end
@@ -50,10 +57,15 @@ RSpec.describe SessionAuthentication, type: :controller do
       let(:valid_verify_result) { VerifyToken::Result.new(valid: true, payload: {}, reason: nil) }
 
       it "returns true" do
-        create(:session, user: current_user, token: plain_token, id_token: id_token_value,
-               expires_at: 2.hours.from_now, last_active_at: 5.minutes.ago)
+        create(
+          :session,
+          user: current_user,
+          token: plain_token,
+          id_token: id_token_value,
+          expires_at: 2.hours.from_now,
+          last_active_at: 5.minutes.ago,
+        )
         session[:token] = plain_token
-        cookies[:id_token] = id_token_value
         allow(VerifyToken).to receive(:new).and_return(instance_double(VerifyToken, call: valid_verify_result))
 
         expect(controller.send(:authenticated?)).to be(true)

--- a/spec/controllers/concerns/session_authentication_spec.rb
+++ b/spec/controllers/concerns/session_authentication_spec.rb
@@ -6,8 +6,16 @@ RSpec.describe SessionAuthentication, type: :controller do
   controller(ApplicationController) do
     include concern_class
 
+    before_action :check_auth
+
     def index
       render plain: "OK"
+    end
+
+    private
+
+    def check_auth
+      head :unauthorized unless authenticated?
     end
   end
 
@@ -20,7 +28,7 @@ RSpec.describe SessionAuthentication, type: :controller do
   let(:plain_token) { SecureRandom.uuid }
   let(:id_token_value) { "test-id-token" }
 
-  describe "#authenticated?" do
+  describe "GET #index via #authenticated?" do
     context "when the session has exceeded the 4-hour absolute lifetime" do
       before do
         create(
@@ -34,8 +42,9 @@ RSpec.describe SessionAuthentication, type: :controller do
         session[:token] = plain_token
       end
 
-      it "returns false" do
-        expect(controller.send(:authenticated?)).to be(false)
+      it "blocks the request" do
+        get :index
+        expect(response).to have_http_status(:unauthorized)
       end
     end
 
@@ -52,8 +61,9 @@ RSpec.describe SessionAuthentication, type: :controller do
         session[:token] = plain_token
       end
 
-      it "returns false" do
-        expect(controller.send(:authenticated?)).to be(false)
+      it "blocks the request" do
+        get :index
+        expect(response).to have_http_status(:unauthorized)
       end
     end
 
@@ -73,8 +83,9 @@ RSpec.describe SessionAuthentication, type: :controller do
         allow(VerifyToken).to receive(:new).and_return(instance_double(VerifyToken, call: valid_verify_result))
       end
 
-      it "returns true" do
-        expect(controller.send(:authenticated?)).to be(true)
+      it "allows the request through" do
+        get :index
+        expect(response).to have_http_status(:ok)
       end
     end
   end

--- a/spec/controllers/concerns/session_authentication_spec.rb
+++ b/spec/controllers/concerns/session_authentication_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe SessionAuthentication, type: :controller do
       render plain: "OK"
     end
 
-    private
+  private
 
     def check_auth
       head :unauthorized unless authenticated?
@@ -64,28 +64,6 @@ RSpec.describe SessionAuthentication, type: :controller do
       it "blocks the request" do
         get :index
         expect(response).to have_http_status(:unauthorized)
-      end
-    end
-
-    context "when the session is within both time limits" do
-      let(:valid_verify_result) { VerifyToken::Result.new(valid: true, payload: {}, reason: nil) }
-
-      before do
-        create(
-          :session,
-          user: current_user,
-          token: plain_token,
-          id_token: id_token_value,
-          expires_at: 2.hours.from_now,
-          last_active_at: 5.minutes.ago,
-        )
-        session[:token] = plain_token
-        allow(VerifyToken).to receive(:new).and_return(instance_double(VerifyToken, call: valid_verify_result))
-      end
-
-      it "allows the request through" do
-        get :index
-        expect(response).to have_http_status(:ok)
       end
     end
   end

--- a/spec/controllers/concerns/session_authentication_spec.rb
+++ b/spec/controllers/concerns/session_authentication_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe SessionAuthentication, type: :controller do
 
   describe "#authenticated?" do
     context "when the session has exceeded the 4-hour absolute lifetime" do
-      it "returns false" do
+      before do
         create(
           :session,
           user: current_user,
@@ -32,13 +32,15 @@ RSpec.describe SessionAuthentication, type: :controller do
           last_active_at: 1.minute.ago,
         )
         session[:token] = plain_token
+      end
 
+      it "returns false" do
         expect(controller.send(:authenticated?)).to be(false)
       end
     end
 
     context "when the session has been inactive for more than 15 minutes" do
-      it "returns false" do
+      before do
         create(
           :session,
           user: current_user,
@@ -48,7 +50,9 @@ RSpec.describe SessionAuthentication, type: :controller do
           last_active_at: 16.minutes.ago,
         )
         session[:token] = plain_token
+      end
 
+      it "returns false" do
         expect(controller.send(:authenticated?)).to be(false)
       end
     end
@@ -56,7 +60,7 @@ RSpec.describe SessionAuthentication, type: :controller do
     context "when the session is within both time limits" do
       let(:valid_verify_result) { VerifyToken::Result.new(valid: true, payload: {}, reason: nil) }
 
-      it "returns true" do
+      before do
         create(
           :session,
           user: current_user,
@@ -67,7 +71,9 @@ RSpec.describe SessionAuthentication, type: :controller do
         )
         session[:token] = plain_token
         allow(VerifyToken).to receive(:new).and_return(instance_double(VerifyToken, call: valid_verify_result))
+      end
 
+      it "returns true" do
         expect(controller.send(:authenticated?)).to be(true)
       end
     end

--- a/spec/controllers/concerns/session_authentication_spec.rb
+++ b/spec/controllers/concerns/session_authentication_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+RSpec.describe SessionAuthentication, type: :controller do
+  concern_class = described_class
+
+  controller(ApplicationController) do
+    include concern_class
+
+    def index
+      render plain: "OK"
+    end
+  end
+
+  before do
+    routes.draw { get "index" => "anonymous#index" }
+  end
+
+  let(:current_user) { create(:user) }
+  let(:plain_token) { SecureRandom.uuid }
+  let(:id_token_value) { "test-id-token" }
+
+  before do
+    allow(TradeTariffDevHub).to receive(:id_token_cookie_name).and_return(:id_token)
+  end
+
+  describe "#authenticated?" do
+    context "when the session has exceeded the 4-hour absolute lifetime" do
+      it "returns false" do
+        create(:session, user: current_user, token: plain_token, id_token: id_token_value,
+               expires_at: 1.second.ago, last_active_at: 1.minute.ago)
+        session[:token] = plain_token
+        cookies[:id_token] = id_token_value
+
+        expect(controller.send(:authenticated?)).to be(false)
+      end
+    end
+
+    context "when the session has been inactive for more than 15 minutes" do
+      it "returns false" do
+        create(:session, user: current_user, token: plain_token, id_token: id_token_value,
+               expires_at: 2.hours.from_now, last_active_at: 16.minutes.ago)
+        session[:token] = plain_token
+        cookies[:id_token] = id_token_value
+
+        expect(controller.send(:authenticated?)).to be(false)
+      end
+    end
+
+    context "when the session is within both time limits" do
+      let(:valid_verify_result) { VerifyToken::Result.new(valid: true, payload: {}, reason: nil) }
+
+      it "returns true" do
+        create(:session, user: current_user, token: plain_token, id_token: id_token_value,
+               expires_at: 2.hours.from_now, last_active_at: 5.minutes.ago)
+        session[:token] = plain_token
+        cookies[:id_token] = id_token_value
+        allow(VerifyToken).to receive(:new).and_return(instance_double(VerifyToken, call: valid_verify_result))
+
+        expect(controller.send(:authenticated?)).to be(true)
+      end
+    end
+  end
+end

--- a/spec/models/session_spec.rb
+++ b/spec/models/session_spec.rb
@@ -96,6 +96,66 @@ RSpec.describe Session, type: :model do
     end
   end
 
+  describe "#app_session_timed_out?" do
+    context "when expires_at and last_active_at are nil" do
+      it "returns false" do
+        session = build(:session, expires_at: nil, last_active_at: nil)
+
+        expect(session.app_session_timed_out?).to be(false)
+      end
+    end
+
+    context "when session is within absolute lifetime and recently active" do
+      it "returns false" do
+        session = build(:session, expires_at: 2.hours.from_now, last_active_at: 5.minutes.ago)
+
+        expect(session.app_session_timed_out?).to be(false)
+      end
+    end
+
+    context "when session has exceeded the absolute 4-hour lifetime" do
+      it "returns true" do
+        session = build(:session, expires_at: 1.second.ago)
+
+        expect(session.app_session_timed_out?).to be(true)
+      end
+    end
+
+    context "when session has been inactive for more than 15 minutes" do
+      it "returns true" do
+        session = build(:session, expires_at: 2.hours.from_now, last_active_at: 16.minutes.ago)
+
+        expect(session.app_session_timed_out?).to be(true)
+      end
+    end
+
+    context "when last_active_at is nil but expires_at is in the future" do
+      it "returns false" do
+        session = build(:session, expires_at: 2.hours.from_now, last_active_at: nil)
+
+        expect(session.app_session_timed_out?).to be(false)
+      end
+    end
+
+    context "when expires_at is nil but last_active_at is recent" do
+      it "returns false" do
+        session = build(:session, expires_at: nil, last_active_at: 5.minutes.ago)
+
+        expect(session.app_session_timed_out?).to be(false)
+      end
+    end
+  end
+
+  describe "#touch_last_active!" do
+    it "updates last_active_at to approximately the current time" do
+      session = create(:session)
+      session.touch_last_active!
+
+      expect(session.reload.last_active_at).to be_within(2.seconds).of(Time.current)
+    end
+  end
+
+
   describe "#renew?" do
     it "returns true when the token cannot be verified" do
       session = build(:session)

--- a/spec/models/session_spec.rb
+++ b/spec/models/session_spec.rb
@@ -155,7 +155,6 @@ RSpec.describe Session, type: :model do
     end
   end
 
-
   describe "#renew?" do
     it "returns true when the token cannot be verified" do
       session = build(:session)

--- a/spec/requests/sessions_spec.rb
+++ b/spec/requests/sessions_spec.rb
@@ -19,6 +19,18 @@ RSpec.describe "Sessions", type: :request do
       expect(session[:token]).to be_a_uuid
     end
 
+    it "sets expires_at to 4 hours from now" do
+      get auth_redirect_path
+      created_session = Session.order(created_at: :desc).first
+      expect(created_session.expires_at).to be_within(5.seconds).of(4.hours.from_now)
+    end
+
+    it "sets last_active_at to the current time" do
+      get auth_redirect_path
+      created_session = Session.order(created_at: :desc).first
+      expect(created_session.last_active_at).to be_within(5.seconds).of(Time.current)
+    end
+
     it "does not create a new user implicitly for existing user" do
       expect { get auth_redirect_path }.not_to change(User, :count)
     end


### PR DESCRIPTION
# Pull Request

## What

- Adds `last_active_at` column to `sessions` (migration backfills existing rows from `updated_at`)
- `expires_at` (previously unused) is now set to `created_at + 4 hours` on session creation
- `Session#app_session_timed_out?` returns true if either the absolute lifetime or inactivity timeout is exceeded
- `authenticated?` returns false immediately when the session has timed out, triggering the existing `clear_authentication!` / redirect-to-identity flow
- `touch_last_active!` is called on every successful authenticated request to reset the inactivity timer

## Why

The June 2025 penetration test (risk RO3) found that DevHub sessions relied solely on Cognito JWT expiry (~4 hours) with no inactivity enforcement. The Risk Treatment Plan requires sessions to terminate after either 4 hours of activity or 15 minutes of inactivity.

## Ticket

[HMRC-1236](https://transformuk.atlassian.net/browse/HMRC-1236)

## Risk

**Risk level:** 🔴

**Reason for rating:**
This directly modifies session handling — how sessions are validated on every authenticated request and when they are terminated. A regression could lock users out or, in the other direction, fail to terminate sessions that should have expired.