### PR TITLE
feat: add api docs header link

### DIFF
--- a/app/lib/trade_tariff_dev_hub.rb
+++ b/app/lib/trade_tariff_dev_hub.rb
@@ -20,7 +20,7 @@ module TradeTariffDevHub
     def api_docs_url
       ENV.fetch(
         "API_DOCS_URL",
-        "https://docs.trade-tariff.service.gov.uk"
+        "https://docs.trade-tariff.service.gov.uk",
       )
     end
 
@@ -92,7 +92,7 @@ module TradeTariffDevHub
     def terms_and_conditions_url
       ENV.fetch(
         "TERMS_AND_CONDITIONS_URL",
-        "https://www.trade-tariff.service.gov.uk/terms",
+        "https://docs.trade-tariff.service.gov.uk/fpo/terms-and-conditions.html",
       )
     end
 

--- a/app/lib/trade_tariff_dev_hub.rb
+++ b/app/lib/trade_tariff_dev_hub.rb
@@ -17,6 +17,13 @@ module TradeTariffDevHub
   ANALYTICS_COOKIE_PREFIXES = %w[_ga _gat _gid].freeze
 
   class << self
+    def api_docs_url
+      ENV.fetch(
+        "API_DOCS_URL",
+        "https://docs.trade-tariff.service.gov.uk"
+      )
+    end
+
     def enquiry_form_url
       ENV.fetch(
         "ENQUIRY_FORM_URL",
@@ -85,7 +92,7 @@ module TradeTariffDevHub
     def terms_and_conditions_url
       ENV.fetch(
         "TERMS_AND_CONDITIONS_URL",
-        "https://api.trade-tariff.service.gov.uk/fpo/terms-and-conditions.html",
+        "https://www.trade-tariff.service.gov.uk/terms",
       )
     end
 

--- a/app/views/layouts/_navigation.html.erb
+++ b/app/views/layouts/_navigation.html.erb
@@ -5,7 +5,7 @@
 
   <%= header.with_navigation_item(text: "API documentation", href: TradeTariffDevHub.api_docs_url) %>
 
-  <%= header.with_navigation_item(text: "Your organisation", href: organisation_path(current_user.organisation), active: current_page?(organisation_path)) %>
+  <%= header.with_navigation_item(text: "Your organisation", href: organisation_path(current_user.organisation), active: current_page?(organisation_path(current_user.organisation))) %>
 
   <% if is_admin %>
     <%= header.with_navigation_item(text: "All organisations", href: admin_organisations_path, active: current_page?(admin_organisations_path)) %>

--- a/app/views/layouts/_navigation.html.erb
+++ b/app/views/layouts/_navigation.html.erb
@@ -3,7 +3,9 @@
   <% is_admin = current_user&.organisation&.admin? %>
   <% viewed_org = organisation %>
 
-  <%= header.with_navigation_item(text: "Your organisation", href: organisation_path(current_user.organisation)) %>
+  <%= header.with_navigation_item(text: "API documentation", href: TradeTariffDevHub.api_docs_url) %>
+
+  <%= header.with_navigation_item(text: "Your organisation", href: organisation_path(current_user.organisation), active: current_page?(organisation_path)) %>
 
   <% if is_admin %>
     <%= header.with_navigation_item(text: "All organisations", href: admin_organisations_path, active: current_page?(admin_organisations_path)) %>


### PR DESCRIPTION
## What

- Add a header navigation item linking to the API documentation

## Why

- After #292, the API docs is now no longer linked on the developer portal

## Ticket

[HMRC-2615](https://transformuk.atlassian.net/browse/HMRC-2615)

## Risk

**Risk level:** 🟢

**Reason for rating:**

- UI addition, no further changes