### PR TITLE
HMRC-2646: Upgrade Alpine base image from 3.23 to 3.24

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG RUBY_VERSION=4.0.6
-ARG ALPINE_VERSION=3.23
+ARG ALPINE_VERSION=3.24
 
 # Build compilation image
 FROM ruby:${RUBY_VERSION}-alpine${ALPINE_VERSION} AS builder


### PR DESCRIPTION
# Pull Request

## What
Upgrade the Docker base image from Alpine 3.23 to Alpine 3.24.

This updates the underlying operating system used by the application containers to the latest Alpine release, bringing in upstream package updates and security patches.

## Why

- Keep the base image up to date with the latest Alpine release.
- Pick up upstream security fixes and package updates.
- Reduce inherited OS-level CVE findings reported by AWS Inspector.
- Ensure the application continues to run on a supported and actively maintained base image.

## Ticket
[HMRC-2646](https://transformuk.atlassian.net/browse/HMRC-2646)

## Risk

**Risk level:** 🟢 

**Reason for rating:**
This is a routine base image upgrade with no application code or behavioural changes. The update is limited to the container's underlying operating system and is intended to apply upstream security patches and reduce inherited vulnerabilities. Existing automated tests and deployment validation should confirm there are no regressions.